### PR TITLE
AB#64547: Amend RO query schema

### DIFF
--- a/app/HutchAgent/hutchagent/ro_crates/query.py
+++ b/app/HutchAgent/hutchagent/ro_crates/query.py
@@ -1,5 +1,5 @@
 import json
-from typing import List, Union
+from typing import List
 
 from hutchagent.ro_crates.group import Group
 from hutchagent.ro_crates.operator import Operator
@@ -12,25 +12,15 @@ class Query:
         self,
         groups: List[Group],
         group_operator: Operator,
-        collection: str,
-        uuid: str,
-        char_salt: str,
-        task_id: str,
-        project: str,
-        owner: str,
-        protocol_version: str,
+        job_id: str,
+        activity_source_id: str,
         context: str = "https://w3id.org/ro/crate/1.1/context",
     ) -> None:
         self.context = context
         self.groups = [] if groups is None else groups
         self.group_operator = group_operator
-        self.collection = collection
-        self.uuid = uuid
-        self.char_salt = char_salt
-        self.task_id = task_id
-        self.project = project
-        self.owner = owner
-        self.protocol_version = protocol_version
+        self.job_id = job_id
+        self.activity_source_id = activity_source_id
 
     def to_dict(self) -> dict:
         """Convert `Query` to `dict`.
@@ -44,44 +34,14 @@ class Query:
                 {
                     "@context": "https://schema.org",
                     "@type": "PropertyValue",
-                    "name": "collection",
-                    "value": self.collection,
+                    "name": "activity_source_id",
+                    "value": self.activity_source_id,
                 },
                 {
                     "@context": "https://schema.org",
                     "@type": "PropertyValue",
-                    "name": "uuid",
-                    "value": self.uuid,
-                },
-                {
-                    "@context": "https://schema.org",
-                    "@type": "PropertyValue",
-                    "name": "char_salt",
-                    "value": self.char_salt,
-                },
-                {
-                    "@context": "https://schema.org",
-                    "@type": "PropertyValue",
-                    "name": "task_id",
-                    "value": self.task_id,
-                },
-                {
-                    "@context": "https://schema.org",
-                    "@type": "PropertyValue",
-                    "name": "project",
-                    "value": self.project,
-                },
-                {
-                    "@context": "https://schema.org",
-                    "@type": "PropertyValue",
-                    "name": "owner",
-                    "value": self.owner,
-                },
-                {
-                    "@context": "https://schema.org",
-                    "@type": "PropertyValue",
-                    "name": "protocol_version",
-                    "value": self.protocol_version,
+                    "name": "job_id",
+                    "value": self.job_id,
                 },
                 self.group_operator.to_dict(),
             ]
@@ -98,46 +58,26 @@ class Query:
         Returns:
             Self: `Query` object.
         """
-        collection = ""
-        uuid = ""
-        task_id = ""
-        char_salt = ""
-        project = ""
-        owner = ""
-        protocol_version = ""
+        job_id = ""
+        activity_source_id = ""
         graph_list = dict_.get("@graph", [])
         groups = []
         group_operator = None
         for g in graph_list:
             if g.get("name") == "groupOperator":
                 group_operator = Operator.from_dict(g)
-            elif g.get("name") == "collection":
-                collection = g.get("value")
-            elif g.get("name") == "uuid":
-                uuid = g.get("value")
-            elif g.get("name") == "task_id":
-                task_id = g.get("value")
-            elif g.get("name") == "char_salt":
-                char_salt = g.get("value")
-            elif g.get("name") == "project":
-                project = g.get("value")
-            elif g.get("name") == "owner":
-                owner = g.get("value")
-            elif g.get("name") == "protocol_version":
-                protocol_version = g.get("value")
+            elif g.get("name") == "job_id":
+                job_id = g.get("value")
+            elif g.get("name") == "activity_source_id":
+                activity_source_id = g.get("value")
             else:
                 groups.append(Group.from_dict(g))
 
         return cls(
             groups=groups,
             group_operator=group_operator,
-            collection=collection,
-            uuid=uuid,
-            task_id=task_id,
-            char_salt=char_salt,
-            project=project,
-            owner=owner,
-            protocol_version=protocol_version,
+            job_id=job_id,
+            activity_source_id=activity_source_id,
         )
 
     def __str__(self) -> str:

--- a/app/HutchAgent/tests/test_ro_crates.py
+++ b/app/HutchAgent/tests/test_ro_crates.py
@@ -4,53 +4,18 @@ from hutchagent.ro_crates.operator import Operator
 from hutchagent.ro_crates.query import Query
 from hutchagent.ro_crates.rule import Rule
 
-PROJECT_DICT = {
+ACTIVITY_SOURCE_ID_DICT = {
     "@context": "https://schema.org",
     "@type": "PropertyValue",
-    "name": "project",
-    "value": "fake_project",
+    "name": "activity_source_id",
+    "value": "fake_activity_source_id",
 }
 
-OWNER_DICT = {
+JOB_ID_DICT = {
     "@context": "https://schema.org",
     "@type": "PropertyValue",
-    "name": "owner",
-    "value": "fake_user",
-}
-
-COLLECTION_DICT = {
-    "@context": "https://schema.org",
-    "@type": "PropertyValue",
-    "name": "collection",
-    "value": "collection id",
-}
-
-UUID_DICT = {
-    "@context": "https://schema.org",
-    "@type": "PropertyValue",
-    "name": "uuid",
-    "value": "not-a-real-uuid",
-}
-
-CHAR_SALT_DICT = {
-    "@context": "https://schema.org",
-    "@type": "PropertyValue",
-    "name": "char_salt",
-    "value": "fake char salt",
-}
-
-TASK_ID_DICT = {
-    "@context": "https://schema.org",
-    "@type": "PropertyValue",
-    "name": "task_id",
-    "value": "fake task id",
-}
-
-PROTOCOL_VERSION_DICT = {
-    "@context": "https://schema.org",
-    "@type": "PropertyValue",
-    "name": "protocol_version",
-    "value": "v2",
+    "name": "job_id",
+    "value": "fake_job_id",
 }
 
 GROUP_OPERATOR_DICT = {
@@ -95,13 +60,8 @@ GROUP_DICT = {
 QUERY_DICT = {
     "@context": "https://w3id.org/ro/crate/1.1/context",
     "@graph": [
-        COLLECTION_DICT,
-        UUID_DICT,
-        CHAR_SALT_DICT,
-        TASK_ID_DICT,
-        PROJECT_DICT,
-        OWNER_DICT,
-        PROTOCOL_VERSION_DICT,
+        ACTIVITY_SOURCE_ID_DICT,
+        JOB_ID_DICT,
         GROUP_OPERATOR_DICT,
         GROUP_DICT,
     ],
@@ -128,11 +88,6 @@ def test_query():
     for g in query.groups:
         assert isinstance(g, Group)
     assert isinstance(query.group_operator, Operator)
-    assert query.project == PROJECT_DICT.get("value")
-    assert query.collection == COLLECTION_DICT.get("value")
-    assert query.char_salt == CHAR_SALT_DICT.get("value")
-    assert query.owner == OWNER_DICT.get("value")
-    assert query.protocol_version == PROTOCOL_VERSION_DICT.get("value")
-    assert query.uuid == UUID_DICT.get("value")
-    assert query.task_id == TASK_ID_DICT.get("value")
+    assert query.activity_source_id == ACTIVITY_SOURCE_ID_DICT.get("value")
+    assert query.job_id == JOB_ID_DICT.get("value")
     assert query.to_dict() == QUERY_DICT


### PR DESCRIPTION
## Overview

Amend the the `Query` class removing the RQuest specific fields.

`Query` now has fields:
- `group_operator`
- `groups`
- `job_id`
- `activity_source_id`

## Azure Boards

- AB#64555
- AB#64556
- AB#64558
