### PR TITLE
AB#64557: Manager terminology updates

### DIFF
--- a/app/HutchManager/Dto/RquestQueryResult.cs
+++ b/app/HutchManager/Dto/RquestQueryResult.cs
@@ -8,16 +8,16 @@ namespace HutchManager.Dto
     /// </summary>
     public class RquestQueryTaskResult
     {
-        public RquestQueryTaskResult(string taskId, int? count = null)
+        public RquestQueryTaskResult(string jobId, int? count = null)
         {
-            TaskId = taskId;
+            JobId = jobId;
 
             if(count.HasValue)
                 QueryResult = new() { Count = count.Value };
         }
 
-        [JsonPropertyName("task_id")]
-        public string TaskId { get; set; }
+        [JsonPropertyName("uuid")]
+        public string JobId { get; set; }
 
         [JsonPropertyName("query_result")]
         public RquestQueryResult? QueryResult { get; set; }

--- a/app/HutchManager/Dto/RquestQueryTask.cs
+++ b/app/HutchManager/Dto/RquestQueryTask.cs
@@ -7,12 +7,13 @@ namespace HutchManager.Dto
     /// </summary>
     public class RquestQueryTask
     {
-        [JsonPropertyName("task_id")]
-        public string TaskId { get; set; } = string.Empty;
+        [JsonPropertyName("uuid")]
+        public string JobId { get; set; } = string.Empty;
 
         [JsonPropertyName("cohort")]
         public RquestQuery Query { get; set; } = new();
-
-        [JsonPropertyName("collection_id")] public string CollectionId { get; set; } = string.Empty;
+        
+        [JsonPropertyName("activity_source_id")] 
+        public int ActivitySourceId { get; set; }
     }
 }


### PR DESCRIPTION
## Overview
- Change TaskId/taskId/task to JobId/jobId/job
- Get uuid from Rquest instead of task_id
- Replace collectionid with resourceID
- Send ActivitySource Id to queue instead of CollectionId
## Azure Boards

- [AB#64557](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/64557)