### PR TITLE
AB#67666: Revert AB#62680

### DIFF
--- a/app/HutchAgent/hutchagent/message_queue.py
+++ b/app/HutchAgent/hutchagent/message_queue.py
@@ -57,14 +57,16 @@ def rquest_callback(
     """
     logger = logging.getLogger(os.getenv("DB_LOGGER_NAME"))
     response_data = {
-        "protocol_version": "v2",
-        "query_result": dict(),
+        "protocolVersion": "2",
+        "queryResult": dict(),
+        "files": list(),
     }
     logger.info("Received message from the Queue. Processing...")
     try:
         body_json = json.loads(body)
         query = RQuestQuery(**body_json)
-        response_data["collection_id"] = query.collection
+        response_data["activity_source_id"] = query.activity_source_id
+        response_data["job_id"] = query.job_id
         logger.info(f"Successfully unpacked message.")
     except json.decoder.JSONDecodeError:
         logger.error("Failed to decode the message from the queue.")
@@ -82,22 +84,22 @@ def rquest_callback(
         res = db_manager.execute_and_fetch(query.to_sql())
         query_end = time.time()
         count_ = res[0][0]
-        response_data["query_result"].update(count=count_, status="ok")
+        response_data["queryResult"].update(count=count_, status="ok")
         logger.info(
-            f"Collected {count_} results from query {query.uuid} in {(query_end - query_start):.3f}s."
+            f"Collected {count_} results from query {query.job_id} in {(query_end - query_start):.3f}s."
         )
     except sql_exc.NoSuchTableError as table_error:
         logger.error(str(table_error))
-        response_data["query_result"].update(count=0, status="error")
+        response_data["queryResult"].update(count=0, status="error")
     except sql_exc.NoSuchColumnError as column_error:
         logger.error(str(column_error))
-        response_data["query_result"].update(count=0, status="error")
+        response_data["queryResult"].update(count=0, status="error")
     except sql_exc.ProgrammingError as programming_error:
         logger.error(str(programming_error))
-        response_data["query_result"].update(count=0, status="error")
+        response_data["queryResult"].update(count=0, status="error")
 
     try:
-        requests.post(os.getenv("MANAGER_URL"), response_data)
+        requests.post(f"{os.getenv('MANAGER_URL')}/api/results", response_data)
         logger.info("Sent results to manager.")
     except req_exc.ConnectionError as connection_error:
         logger.error(str(connection_error))

--- a/app/HutchAgent/hutchagent/message_queue.py
+++ b/app/HutchAgent/hutchagent/message_queue.py
@@ -179,7 +179,7 @@ def ro_crates_callback(
         )
 
     try:
-        requests.post(os.getenv("MANAGER_URL"), result.to_dict())
+        requests.post(f"{os.getenv('MANAGER_URL')}/api/results", result.to_dict())
         logger.info("Sent results to manager.")
     except req_exc.ConnectionError as connection_error:
         logger.error(str(connection_error))

--- a/app/HutchAgent/hutchagent/message_queue.py
+++ b/app/HutchAgent/hutchagent/message_queue.py
@@ -57,16 +57,14 @@ def rquest_callback(
     """
     logger = logging.getLogger(os.getenv("DB_LOGGER_NAME"))
     response_data = {
-        "protocolVersion": "2",
-        "queryResult": dict(),
-        "files": list(),
+        "protocol_version": "v2",
+        "query_result": dict(),
     }
     logger.info("Received message from the Queue. Processing...")
     try:
         body_json = json.loads(body)
-        query = RQuestQuery.from_dict(body_json)
-        response_data["activity_source_id"] = query.activity_source_id
-        response_data["job_id"] = query.job_id
+        query = RQuestQuery(**body_json)
+        response_data["collection_id"] = query.collection
         logger.info(f"Successfully unpacked message.")
     except json.decoder.JSONDecodeError:
         logger.error("Failed to decode the message from the queue.")
@@ -84,102 +82,22 @@ def rquest_callback(
         res = db_manager.execute_and_fetch(query.to_sql())
         query_end = time.time()
         count_ = res[0][0]
-        response_data["queryResult"].update(count=count_, status="ok")
+        response_data["query_result"].update(count=count_, status="ok")
         logger.info(
-            f"Collected {count_} results from query {query.job_id} in {(query_end - query_start):.3f}s."
+            f"Collected {count_} results from query {query.uuid} in {(query_end - query_start):.3f}s."
         )
     except sql_exc.NoSuchTableError as table_error:
         logger.error(str(table_error))
-        response_data["queryResult"].update(count=0, status="error")
+        response_data["query_result"].update(count=0, status="error")
     except sql_exc.NoSuchColumnError as column_error:
         logger.error(str(column_error))
-        response_data["queryResult"].update(count=0, status="error")
+        response_data["query_result"].update(count=0, status="error")
     except sql_exc.ProgrammingError as programming_error:
         logger.error(str(programming_error))
-        response_data["queryResult"].update(count=0, status="error")
+        response_data["query_result"].update(count=0, status="error")
 
     try:
-        requests.post(f"{os.getenv('MANAGER_URL')}/api/results", response_data)
-        logger.info("Sent results to manager.")
-    except req_exc.ConnectionError as connection_error:
-        logger.error(str(connection_error))
-    except req_exc.Timeout as timeout_error:
-        logger.error(str(timeout_error))
-    except req_exc.MissingSchema as missing_schema_error:
-        logger.error(str(missing_schema_error))
-
-
-def ro_crates_callback(
-    channel: Channel, method: Basic.Deliver, properties: BasicProperties, body: bytes
-):
-    """The callback to be used when consuming messages from the queue.
-    The arguments to this function will be passed by the channel when a
-    message is consumed.
-
-    Args:
-        channel (Channel): The channel object.
-        method (Deliver): The delivery object.
-        properties (BasicProperties): The message properties.
-        body (bytes): The body of the message.
-    """
-    logger = logging.getLogger(os.getenv("DB_LOGGER_NAME"))
-    logger.info("Received message from the Queue. Processing...")
-    try:
-        body_json = json.loads(body)
-        query = Query.from_dict(body_json)
-        logger.info(f"Successfully unpacked message.")
-    except json.decoder.JSONDecodeError:
-        logger.error("Failed to decode the message from the queue.")
-
-    db_manager = SyncDBManager(
-        username=os.getenv("DATASOURCE_DB_USERNAME"),
-        password=os.getenv("DATASOURCE_DB_PASSWORD"),
-        host=os.getenv("DATASOURCE_DB_HOST"),
-        port=int(os.getenv("DATASOURCE_DB_PORT")),
-        database=os.getenv("DATASOURCE_DB_DATABASE"),
-        drivername=os.getenv("DATASOURCE_DB_DRIVERNAME"),
-    )
-    try:
-        query_start = time.time()
-        res = db_manager.execute_and_fetch(query.to_sql())
-        query_end = time.time()
-        count_ = res[0][0]
-        logger.info(
-            f"Collected {count_} results from query in {(query_end - query_start):.3f}s."
-        )
-        result = Result(
-            activity_source_id=query.activity_source_id,
-            job_id=query.job_id,
-            status="ok",
-            count=count_,
-        )
-    except sql_exc.NoSuchTableError as table_error:
-        logger.error(str(table_error))
-        result = Result(
-            activity_source_id=query.activity_source_id,
-            job_id=query.job_id,
-            status="error",
-            count=0,
-        )
-    except sql_exc.NoSuchColumnError as column_error:
-        logger.error(str(column_error))
-        result = Result(
-            activity_source_id=query.activity_source_id,
-            job_id=query.job_id,
-            status="error",
-            count=0,
-        )
-    except sql_exc.ProgrammingError as programming_error:
-        logger.error(str(programming_error))
-        result = Result(
-            activity_source_id=query.activity_source_id,
-            job_id=query.job_id,
-            status="error",
-            count=0,
-        )
-
-    try:
-        requests.post(f"{os.getenv('MANAGER_URL')}/api/results", result.to_dict())
+        requests.post(os.getenv("MANAGER_URL"), response_data)
         logger.info("Sent results to manager.")
     except req_exc.ConnectionError as connection_error:
         logger.error(str(connection_error))

--- a/app/HutchAgent/hutchagent/message_queue.py
+++ b/app/HutchAgent/hutchagent/message_queue.py
@@ -58,8 +58,7 @@ def rquest_callback(
     logger = logging.getLogger(os.getenv("DB_LOGGER_NAME"))
     response_data = {
         "protocolVersion": "2",
-        "queryResult": dict(),
-        "files": list(),
+        "queryResult": dict(files=list()),
     }
     logger.info("Received message from the Queue. Processing...")
     try:
@@ -84,19 +83,23 @@ def rquest_callback(
         res = db_manager.execute_and_fetch(query.to_sql())
         query_end = time.time()
         count_ = res[0][0]
-        response_data["queryResult"].update(count=count_, status="ok")
+        response_data["queryResult"].update(count=count_)
+        response_data.update(status="ok")
         logger.info(
             f"Collected {count_} results from query {query.job_id} in {(query_end - query_start):.3f}s."
         )
     except sql_exc.NoSuchTableError as table_error:
         logger.error(str(table_error))
-        response_data["queryResult"].update(count=0, status="error")
+        response_data["queryResult"].update(count=0)
+        response_data.update(status="error")
     except sql_exc.NoSuchColumnError as column_error:
         logger.error(str(column_error))
-        response_data["queryResult"].update(count=0, status="error")
+        response_data["queryResult"].update(count=0)
+        response_data.update(status="error")
     except sql_exc.ProgrammingError as programming_error:
         logger.error(str(programming_error))
-        response_data["queryResult"].update(count=0, status="error")
+        response_data["queryResult"].update(count=0)
+        response_data.update(status="error")
 
     try:
         requests.post(f"{os.getenv('MANAGER_URL')}/api/results", response_data)

--- a/app/HutchAgent/hutchagent/query.py
+++ b/app/HutchAgent/hutchagent/query.py
@@ -267,7 +267,7 @@ class RQuestQuery:
         self.cohort = cohort if cohort is not None else {}  # turn None to empty dict
         self.cohort = RQuestQueryCohort(**cohort)
         self.job_id = job_id
-        self.uuid = activity_source_id
+        self.activity_source_id = activity_source_id
 
     def to_sql(self):
         columns = set()

--- a/app/HutchAgent/hutchagent/query.py
+++ b/app/HutchAgent/hutchagent/query.py
@@ -10,7 +10,6 @@ from sqlalchemy import (
     select,
 )
 from typing import Any
-from hutchagent.db_manager import SyncDBManager
 from hutchagent.entities import ConditionOccurrence, Measurement, Observation, Person
 
 dotenv.load_dotenv()

--- a/app/HutchAgent/hutchagent/query.py
+++ b/app/HutchAgent/hutchagent/query.py
@@ -1,18 +1,9 @@
 import datetime as dt
-import json
-import logging
-import os
 import re
-import time
 import dotenv
-import requests, requests.exceptions as req_exc
-from pika.channel import Channel
-from pika.spec import Basic, BasicProperties
 from sqlalchemy import (
     and_,
     column,
-    create_engine,
-    exc as sql_exc,
     func,
     not_,
     or_,

--- a/app/HutchAgent/hutchagent/query.py
+++ b/app/HutchAgent/hutchagent/query.py
@@ -198,12 +198,13 @@ class RQuestQueryRule:
 class RQuestQueryGroup:
     """Represents an RQuest query group."""
 
-    def __init__(self, rules: list = None, rules_oper: str = "") -> None:
+    def __init__(self, rules: list = None, rules_oper: str = "", exclude: bool = False) -> None:
         """Constructor for `RQuestQueryGroup`.
 
         Args:
             rules (list, optional): A list of `RQuestQueryRule`s. Defaults to None.
             rules_oper (str, optional): The operand for comparing the rules. Defaults to "".
+            exclude (bool, optional): Exclude results match the group rules. Defaults to False.
         """
         self.rules = (
             [RQuestQueryRule(**r) for r in rules] if rules is not None else list()
@@ -211,6 +212,7 @@ class RQuestQueryGroup:
         # Sort rules for more predictable behaviour in tests.
         self.rules = sorted(self.rules, key=lambda x: x.column_name)
         self.rules_oper = rules_oper
+        self.exclude = exclude
 
     @property
     def columns(self):

--- a/app/HutchAgent/hutchagent/query.py
+++ b/app/HutchAgent/hutchagent/query.py
@@ -1,15 +1,25 @@
 import datetime as dt
+import json
+import logging
+import os
 import re
+import time
 import dotenv
+import requests, requests.exceptions as req_exc
+from pika.channel import Channel
+from pika.spec import Basic, BasicProperties
 from sqlalchemy import (
     and_,
     column,
+    create_engine,
+    exc as sql_exc,
     func,
     not_,
     or_,
     select,
 )
-from typing import Any, Union, List
+from typing import Any
+from hutchagent.db_manager import SyncDBManager
 from hutchagent.entities import ConditionOccurrence, Measurement, Observation, Person
 
 dotenv.load_dotenv()
@@ -28,50 +38,29 @@ class RQuestQueryRule:
 
     def __init__(
         self,
-        variable_name: str = "",
-        type_: str = "",
-        operand: str = "",
+        varname: str = "",
+        type: str = "",
+        oper: str = "",
         value: str = "",
-        external_attribute: str = "",
-        unit: str = "",
-        regex: str = "",
-        time_: Union[str, None] = None,
+        **kwargs,
     ) -> None:
         """Constructor for `RQuestQueryRule`.
 
         Args:
-            variable_name (str, optional): The name of the value column. Defaults to "".
+            varname (str, optional): The name of the value column. Defaults to "".
             type (str, optional): The data type of the value. Defaults to "".
-            operand (str, optional): The comparison operator for the value. Defaults to "".
-            value (str, optional): The value. Defaults to "".
-            external_attribute (str, optional): An additional attribute. Defaults to "".
-            unit (str, optional): The units of the rule. Defaults to "".
-            regex (str, optional): The regex to match. Defaults to "".
-            time_ (Union[str, None], optional): The time boundry for the rule. Defaults to None.
+            oper (str, optional): The comparison operator for the value. Defaults to "".
+            value (str, optional): The value. Defaults to "". Is converted from a string
+            to the type specified in `type`.
         """
-        self.concept_id = self._parse_concept_id(variable_name, value)
-        self.variable_name = variable_name
-        self.type_ = type_
-        self.operand = operand
+        self.concept_id = self._parse_concept_id(varname, value)
+        self.varname = varname
+        self.type = type
+        self.oper = oper
         self.value = self._parse_value(value)
-        self.external_attribute = external_attribute
-        self.unit = unit
-        self.regex = regex
         self.column_name = PERSON_LOOKUPS.get(self.concept_id)
-        self.time_ = time_
-
-    @classmethod
-    def from_dict(cls, dict_: dict):
-        return cls(
-            variable_name=dict_.get("VariableName", ""),
-            type_=dict_.get("Type", ""),
-            operand=dict_.get("Operand", ""),
-            value=dict_.get("Value", ""),
-            external_attribute=dict_.get("ExternalAttribute", ""),
-            unit=dict_.get("Unit", ""),
-            regex=dict_.get("RegEx", ""),
-            time_=dict_.get("Time"),  # time_ defaults to None.
-        )
+        # `time` is not always present so either get from `kwargs` or default to `None`
+        self.time_ = kwargs.get("time")
 
     def _parse_value(self, value: str) -> Any:
         """Parse string value into correct type.
@@ -82,20 +71,20 @@ class RQuestQueryRule:
         Returns:
             Any: The value with the correct type.
         """
-        if self.type_ == "NUM":
+        if self.type == "NUM":
             return self._numeric_value(value)
         else:
             return value
 
     @property
     def sql_clause(self):
-        if self.column_name is None and self.operand == "=":
+        if self.column_name is None and self.oper == "=":
             return or_(
                 column("measurement_concept_id") == self.concept_id,
                 column("observation_concept_id") == self.concept_id,
                 column("condition_concept_id") == self.concept_id,
             )
-        if self.column_name is None and self.operand == "!=":
+        if self.column_name is None and self.oper == "!=":
             return or_(
                 column("measurement_concept_id") != self.concept_id,
                 column("observation_concept_id") != self.concept_id,
@@ -103,13 +92,13 @@ class RQuestQueryRule:
             )
 
         clause = None
-        if self.type_ == "TEXT" and self.operand == "=":
+        if self.type == "TEXT" and self.oper == "=":
             clause = column(self.column_name) == self.concept_id
-        elif self.type_ == "TEXT" and self.operand == "!=":
+        elif self.type == "TEXT" and self.oper == "!=":
             clause = column(self.column_name) != self.concept_id
-        elif self.type_ == "NUM" and self.operand == "=":
+        elif self.type == "NUM" and self.oper == "=":
             clause = column(self.column_name).between(self.value[0], self.value[1])
-        elif self.type_ == "NUM" and self.operand == "!=":
+        elif self.type == "NUM" and self.oper == "!=":
             clause = not_(
                 column(self.column_name).between(self.value[0], self.value[1])
             )
@@ -155,20 +144,20 @@ class RQuestQueryRule:
             timespan = int(hit.group(1))
             time_unit = hit.group(2)
             # older times are smaller, so use `>` for inclusive ("=") seaches
-            if time_unit == "Y" and self.operand == "=":
+            if time_unit == "Y" and self.oper == "=":
                 return column("birth_datetime") < (
                     dt.datetime.now() - dt.timedelta(days=365 * timespan)
                 )
-            elif time_unit == "M" and self.operand == "=":
+            elif time_unit == "M" and self.oper == "=":
                 return column("birth_datetime") < (
                     dt.datetime.now() - dt.timedelta(weeks=4.33 * timespan)
                 )
             # newer times are larger, so use `<=` for exclusive ("!=") seaches
-            elif time_unit == "Y" and self.operand == "!=":
+            elif time_unit == "Y" and self.oper == "!=":
                 return column("birth_datetime") >= (
                     dt.datetime.now() - dt.timedelta(days=365 * timespan)
                 )
-            elif time_unit == "M" and self.operand == "!=":
+            elif time_unit == "M" and self.oper == "!=":
                 return column("birth_datetime") >= (
                     dt.datetime.now() - dt.timedelta(weeks=4.33 * timespan)
                 )
@@ -180,20 +169,20 @@ class RQuestQueryRule:
             timespan = int(hit.group(1))
             time_unit = hit.group(2)
             # newer times are larger, so use `>` for inclusive ("=") seaches
-            if time_unit == "Y" and self.operand == "=":
+            if time_unit == "Y" and self.oper == "=":
                 return column("birth_datetime") > (
                     dt.datetime.now() - dt.timedelta(days=365 * timespan)
                 )
-            elif time_unit == "M" and self.operand == "=":
+            elif time_unit == "M" and self.oper == "=":
                 return column("birth_datetime") > (
                     dt.datetime.now() - dt.timedelta(weeks=4.33 * timespan)
                 )
             # older times are smaller, so use `<=` for exclusive ("!=") seaches
-            elif time_unit == "Y" and self.operand == "!=":
+            elif time_unit == "Y" and self.oper == "!=":
                 return column("birth_datetime") <= (
                     dt.datetime.now() - dt.timedelta(days=365 * timespan)
                 )
-            elif time_unit == "M" and self.operand == "!=":
+            elif time_unit == "M" and self.oper == "!=":
                 return column("birth_datetime") <= (
                     dt.datetime.now() - dt.timedelta(weeks=4.33 * timespan)
                 )
@@ -209,29 +198,19 @@ class RQuestQueryRule:
 class RQuestQueryGroup:
     """Represents an RQuest query group."""
 
-    def __init__(
-        self, rules: list = None, combinator: str = "", exclude: bool = False
-    ) -> None:
+    def __init__(self, rules: list = None, rules_oper: str = "") -> None:
         """Constructor for `RQuestQueryGroup`.
 
         Args:
             rules (list, optional): A list of `RQuestQueryRule`s. Defaults to None.
-            combinator (str, optional): The operand for comparing the rules. Defaults to "".
-            exclude (bool, optional): Exclude results matching `rules`. Defaults to False.
+            rules_oper (str, optional): The operand for comparing the rules. Defaults to "".
         """
-        self.rules = rules
+        self.rules = (
+            [RQuestQueryRule(**r) for r in rules] if rules is not None else list()
+        )
         # Sort rules for more predictable behaviour in tests.
         self.rules = sorted(self.rules, key=lambda x: x.column_name)
-        self.combinator = combinator
-        self.exclude = exclude
-
-    @classmethod
-    def from_dict(cls, dict_: dict):
-        return cls(
-            rules=[RQuestQueryRule.from_dict(rule) for rule in dict_.get("Rules", [])],
-            combinator=dict_.get("Combinator", ""),
-            exclude=dict_.get("Exclude", False),
-        )
+        self.rules_oper = rules_oper
 
     @property
     def columns(self):
@@ -239,10 +218,33 @@ class RQuestQueryGroup:
 
     @property
     def sql_clause(self):
-        if self.combinator == "AND":
+        if self.rules_oper == "AND":
             return and_(*[rule.sql_clause for rule in self.rules])
         else:
             return or_(*[rule.sql_clause for rule in self.rules])
+
+
+class RQuestQueryCohort:
+    """Represents an RQuest query cohort."""
+
+    def __init__(self, groups: list = None, groups_oper: str = "") -> None:
+        """Constructor for `RQuestQueryCohort`.
+
+        Args:
+            groups (list, optional): A list of `RQuestQueryGroup`s. Defaults to None.
+            groups_oper (str, optional): The operand for comparing the groups. Defaults to "".
+        """
+        self.groups = (
+            [RQuestQueryGroup(**g) for g in groups] if groups is not None else list()
+        )
+        self.groups_oper = groups_oper
+
+    @property
+    def sql_clause(self):
+        if self.groups_oper == "AND":
+            return and_(*[group.sql_clause for group in self.groups])
+        else:
+            return or_(*[group.sql_clause for group in self.groups])
 
 
 class RQuestQuery:
@@ -250,50 +252,35 @@ class RQuestQuery:
 
     def __init__(
         self,
-        job_id: str = "",
-        activity_source_id: str = "",
-        groups: List[RQuestQueryGroup] = None,
-        combinator: str = "",
+        owner: str = "",
+        cohort: dict = None,  # mutable types shouldn't used as defaults
+        collection: str = "",
+        protocol_version: str = "",
+        char_salt: str = "",
+        uuid: str = "",
+        **kwargs,  # ignored args
     ) -> None:
         """Construction for `RQuestQuery`.
 
         Args:
-            job_id (str, optional): _description_. Defaults to "".
-            activity_source_id (str, optional): _description_. Defaults to "".
-            groups (List[RQuestQueryGroup], optional): _description_. Defaults to None.
-            combinator (str, optional): _description_. Defaults to "".
+            owner (str, optional): The owner of the query. Defaults to "".
+            cohort (dict, optional): The cohort of groups. Defaults to None.
+            collection (str, optional): The collection ID. Defaults to "".
+            protocol_version (str, optional): The protocol version. Defaults to "".
+            char_salt (str, optional): The char salt. Defaults to "".
+            uuid (str, optional): The UUID. Defaults to "".
         """
-        self.job_id = job_id
-        self.activity_source_id = activity_source_id
-        self.groups = groups if groups is not None else list()
-        self.combinator = combinator
-
-    @classmethod
-    def from_dict(cls, dict_: dict):
-        job_id = dict_.get("JobId", "")
-        activity_source_id = dict_.get("ActivitySourceId", "")
-        query = dict_.get("Query", dict())
-        combinator = query.get("Combinator", "")
-        groups = [
-            RQuestQueryGroup.from_dict(group) for group in query.get("Groups", dict())
-        ]
-        return cls(
-            job_id=job_id,
-            activity_source_id=activity_source_id,
-            combinator=combinator,
-            groups=groups,
-        )
-
-    @property
-    def sql_clause(self):
-        if self.combinator == "AND":
-            return and_(*[group.sql_clause for group in self.groups])
-        else:
-            return or_(*[group.sql_clause for group in self.groups])
+        self.owner = owner
+        self.cohort = cohort if cohort is not None else {}  # turn None to empty dict
+        self.cohort = RQuestQueryCohort(**cohort)
+        self.collection = collection
+        self.protocol_version = protocol_version
+        self.char_salt = char_salt
+        self.uuid = uuid
 
     def to_sql(self):
         columns = set()
-        for group in self.groups:
+        for group in self.cohort.groups:
             for col in group.columns:
                 columns.add(col)
         # Make columns appear in ascending order by name for tests.
@@ -313,7 +300,7 @@ class RQuestQuery:
                 Observation,
                 Person.person_id == Observation.person_id,
             )
-            .where(self.sql_clause)
+            .where(self.cohort.sql_clause)
             .distinct()
             .subquery()
         )

--- a/app/HutchAgent/hutchagent/query.py
+++ b/app/HutchAgent/hutchagent/query.py
@@ -42,7 +42,10 @@ class RQuestQueryRule:
         type: str = "",
         oper: str = "",
         value: str = "",
-        **kwargs,
+        time: str = "",
+        ext: str = "",
+        regex: str = "",
+        unit: str = "",
     ) -> None:
         """Constructor for `RQuestQueryRule`.
 
@@ -59,8 +62,10 @@ class RQuestQueryRule:
         self.oper = oper
         self.value = self._parse_value(value)
         self.column_name = PERSON_LOOKUPS.get(self.concept_id)
-        # `time` is not always present so either get from `kwargs` or default to `None`
-        self.time_ = kwargs.get("time")
+        self.time_ = time
+        self.ext = ext
+        self.regex = regex
+        self.unit = unit
 
     def _parse_value(self, value: str) -> Any:
         """Parse string value into correct type.
@@ -104,7 +109,7 @@ class RQuestQueryRule:
             )
 
         # If there is a time clause, combine with main clause.
-        if self.time_ is not None:
+        if self.time_ != "":
             clause = and_(clause, self._get_time_clause())
 
         return clause

--- a/app/HutchAgent/hutchagent/query.py
+++ b/app/HutchAgent/hutchagent/query.py
@@ -203,7 +203,9 @@ class RQuestQueryRule:
 class RQuestQueryGroup:
     """Represents an RQuest query group."""
 
-    def __init__(self, rules: list = None, rules_oper: str = "", exclude: bool = False) -> None:
+    def __init__(
+        self, rules: list = None, rules_oper: str = "", exclude: bool = False
+    ) -> None:
         """Constructor for `RQuestQueryGroup`.
 
         Args:

--- a/app/HutchAgent/hutchagent/query.py
+++ b/app/HutchAgent/hutchagent/query.py
@@ -252,31 +252,22 @@ class RQuestQuery:
 
     def __init__(
         self,
-        owner: str = "",
+        job_id: str = "",
+        activity_source_id: str = "",
         cohort: dict = None,  # mutable types shouldn't used as defaults
-        collection: str = "",
-        protocol_version: str = "",
-        char_salt: str = "",
-        uuid: str = "",
         **kwargs,  # ignored args
     ) -> None:
         """Construction for `RQuestQuery`.
 
         Args:
-            owner (str, optional): The owner of the query. Defaults to "".
+            job_id (str, optional): The job ID of the query. Defaults to "".
+            activity_source_id (str, optional): The activity source ID of the query. Defaults to "".
             cohort (dict, optional): The cohort of groups. Defaults to None.
-            collection (str, optional): The collection ID. Defaults to "".
-            protocol_version (str, optional): The protocol version. Defaults to "".
-            char_salt (str, optional): The char salt. Defaults to "".
-            uuid (str, optional): The UUID. Defaults to "".
         """
-        self.owner = owner
         self.cohort = cohort if cohort is not None else {}  # turn None to empty dict
         self.cohort = RQuestQueryCohort(**cohort)
-        self.collection = collection
-        self.protocol_version = protocol_version
-        self.char_salt = char_salt
-        self.uuid = uuid
+        self.job_id = job_id
+        self.uuid = activity_source_id
 
     def to_sql(self):
         columns = set()

--- a/app/HutchAgent/tests/test_query.py
+++ b/app/HutchAgent/tests/test_query.py
@@ -1,26 +1,70 @@
 import pytest
 import hutchagent.query as query
 
+"""
+{
+    "job_id":"d21599d5-2514-4f63-9183-62ddc47f8e0d",
+    "cohort":{
+        "groups_oper":"OR",
+        "groups":[
+            {
+                "rules_oper":"AND",
+                "rules":[
+                    {
+                        "type":"TEXT",
+                        "varname":"OMOP",
+                        "oper":"=",
+                        "value":"8532",
+                        "time":"|6:TIME:M",
+                        "ext":"",
+                        "unit":"",
+                        "regex":""
+                    },
+                    {
+                        "type":"TEXT",
+                        "varname":"OMOP",
+                        "oper":"=",
+                        "value":"4139681",
+                        "time":"|18:AGE:Y",
+                        "ext":"",
+                        "unit":"",
+                        "regex":""
+                    }
+                ],
+                "exclude":false
+            }
+        ]
+    },
+    "activity_source_id":1
+}
+"""
+
 
 def test_create_rquest_query():
     request_dict = {
-        "owner": "user1",
+        "job_id": "d21599d5-2514-4f63-9183-62ddc47f8e0d",
         "cohort": {
+            "groups_oper": "OR",
             "groups": [
                 {
+                    "rules_oper": "AND",
                     "rules": [
                         {
-                            "varname": "SEX",
-                            "type": "ALTERNATIVE",
+                            "type": "TEXT",
+                            "varname": "OMOP",
                             "oper": "=",
-                            "value": "1",
-                        }
+                            "value": "8532",
+                            "time": "|6:TIME:M",
+                            "ext": "",
+                            "unit": "",
+                            "regex": "",
+                        },
                     ],
-                    "rules_oper": "OR",
-                },
+                    "exclude": False,
+                }
             ],
-            "groups_oper": "AND",
         },
+        "activity_source_id": 1,
     }
     rquest_query = query.RQuestQuery(**request_dict)
     # Assert this created an instance of `RQuestQueryCohort`
@@ -33,6 +77,7 @@ def test_create_rquest_query():
     assert isinstance(rquest_query.cohort.groups[0].rules[0], query.RQuestQueryRule)
 
 
+@pytest.mark.skip
 def test_text_rule_sql_clause():
     eq_rule = {
         "varname": "OMOP",
@@ -49,6 +94,7 @@ def test_text_rule_sql_clause():
     assert str(rule_obj.sql_clause) == "race_concept_id != :race_concept_id_1"
 
 
+@pytest.mark.skip
 def test_numeric_rule_sql_clause():
     eq_rule = {
         "varname": "OMOP=8527",
@@ -71,6 +117,7 @@ def test_numeric_rule_sql_clause():
     )
 
 
+@pytest.mark.skip
 def test_time_rule_sql_clause():
     eq_rule = {
         "varname": "OMOP",
@@ -104,6 +151,7 @@ def test_time_rule_sql_clause():
         print(rule_obj.sql_clause)
 
 
+@pytest.mark.skip
 def test_group_sql_clause():
     and_rule = {
         "rules": [
@@ -135,6 +183,7 @@ def test_group_sql_clause():
     )
 
 
+@pytest.mark.skip
 def test_cohort_sql_clause():
     and_group = {
         "groups": [
@@ -190,6 +239,7 @@ def test_cohort_sql_clause():
     )
 
 
+@pytest.mark.skip
 def test_query_to_sql():
     request_dict = {
         "owner": "user1",

--- a/app/HutchAgent/tests/test_query.py
+++ b/app/HutchAgent/tests/test_query.py
@@ -77,13 +77,16 @@ def test_create_rquest_query():
     assert isinstance(rquest_query.cohort.groups[0].rules[0], query.RQuestQueryRule)
 
 
-@pytest.mark.skip
+
 def test_text_rule_sql_clause():
     eq_rule = {
         "varname": "OMOP",
         "type": "TEXT",
         "oper": "=",
         "value": "8527",
+        "ext": "",
+        "unit": "",
+        "regex": "",
     }
     rule_obj = query.RQuestQueryRule(**eq_rule)
     assert rule_obj.concept_id == "8527"

--- a/app/HutchAgent/tests/test_query.py
+++ b/app/HutchAgent/tests/test_query.py
@@ -4,67 +4,51 @@ import hutchagent.query as query
 
 def test_create_rquest_query():
     request_dict = {
-        "JobId": "88ca2cd8-0438-48ad-be14-dc9326b63234",
-        "Query": {
-            "Combinator": "OR",
-            "Groups": [
+        "owner": "user1",
+        "cohort": {
+            "groups": [
                 {
-                    "Combinator": "AND",
-                    "Rules": [
+                    "rules": [
                         {
-                            "Type": "TEXT",
-                            "VariableName": "OMOP",
-                            "Operand": "=",
-                            "Value": "8532",
-                            "ExternalAttribute": "",
-                            "Unit": "",
-                            "RegEx": "",
-                        },
-                        {
-                            "Type": "TEXT",
-                            "VariableName": "OMOP",
-                            "Operand": "=",
-                            "Value": "8507",
-                            "ExternalAttribute": "",
-                            "Unit": "",
-                            "RegEx": "",
-                        },
+                            "varname": "SEX",
+                            "type": "ALTERNATIVE",
+                            "oper": "=",
+                            "value": "1",
+                        }
                     ],
-                    "Exclude": False,
-                }
+                    "rules_oper": "OR",
+                },
             ],
+            "groups_oper": "AND",
         },
-        "ActivitySourceId": 1,
     }
-    rquest_query = query.RQuestQuery.from_dict(request_dict)
+    rquest_query = query.RQuestQuery(**request_dict)
+    # Assert this created an instance of `RQuestQueryCohort`
+    assert isinstance(rquest_query.cohort, query.RQuestQueryCohort)
     # Assert query groups is a list of `RQuestQueryGroup`
-    assert isinstance(rquest_query.groups, list)
-    assert isinstance(rquest_query.groups[0], query.RQuestQueryGroup)
+    assert isinstance(rquest_query.cohort.groups, list)
+    assert isinstance(rquest_query.cohort.groups[0], query.RQuestQueryGroup)
     # Assert query rules is a list of `RQuestQueryRule`
-    assert isinstance(rquest_query.groups[0].rules, list)
-    assert isinstance(rquest_query.groups[0].rules[0], query.RQuestQueryRule)
+    assert isinstance(rquest_query.cohort.groups[0].rules, list)
+    assert isinstance(rquest_query.cohort.groups[0].rules[0], query.RQuestQueryRule)
 
 
 def test_text_rule_sql_clause():
     eq_rule = {
-        "Type": "TEXT",
-        "VariableName": "OMOP",
-        "Operand": "=",
-        "Value": "8527",
-        "ExternalAttribute": "",
-        "Unit": "",
-        "RegEx": "",
+        "varname": "OMOP",
+        "type": "TEXT",
+        "oper": "=",
+        "value": "8527",
     }
-    rule_obj = query.RQuestQueryRule.from_dict(eq_rule)
+    rule_obj = query.RQuestQueryRule(**eq_rule)
     assert rule_obj.concept_id == "8527"
     assert str(rule_obj.sql_clause) == "race_concept_id = :race_concept_id_1"
     ne_rule = eq_rule.copy()
-    ne_rule.update({"Operand": "!="})
-    rule_obj = query.RQuestQueryRule.from_dict(ne_rule)
+    ne_rule.update(oper="!=")
+    rule_obj = query.RQuestQueryRule(**ne_rule)
     assert str(rule_obj.sql_clause) == "race_concept_id != :race_concept_id_1"
 
 
-@pytest.mark.skip
 def test_numeric_rule_sql_clause():
     eq_rule = {
         "varname": "OMOP=8527",
@@ -87,7 +71,6 @@ def test_numeric_rule_sql_clause():
     )
 
 
-@pytest.mark.skip
 def test_time_rule_sql_clause():
     eq_rule = {
         "varname": "OMOP",
@@ -122,35 +105,29 @@ def test_time_rule_sql_clause():
 
 
 def test_group_sql_clause():
-    or_rule = {
-        "Rules": [
+    and_rule = {
+        "rules": [
             {
-                "Type": "TEXT",
-                "VariableName": "OMOP",
-                "Operand": "=",
-                "Value": "8527",
-                "ExternalAttribute": "",
-                "Unit": "",
-                "RegEx": "",
+                "varname": "OMOP",
+                "type": "TEXT",
+                "oper": "=",
+                "value": "8527",
             },
         ],
-        "Combinator": "OR",
+        "rules_oper": "OR",
     }
-    group = query.RQuestQueryGroup.from_dict(or_rule)
+    group = query.RQuestQueryGroup(**and_rule)
     # Assert single rule in group builds correctly
     assert str(group.sql_clause) == "race_concept_id = :race_concept_id_1"
-    or_rule["Rules"].append(
+    and_rule["rules"].append(
         {
-            "Type": "TEXT",
-            "VariableName": "OMOP",
-            "Operand": "=",
-            "Value": "8532",
-            "ExternalAttribute": "",
-            "Unit": "",
-            "RegEx": "",
+            "varname": "OMOP",
+            "type": "TEXT",
+            "oper": "=",
+            "value": "8532",
         },
     )
-    group = query.RQuestQueryGroup.from_dict(or_rule)
+    group = query.RQuestQueryGroup(**and_rule)
     # Assert multiple rules in group build correctly
     assert (
         str(group.sql_clause)
@@ -158,32 +135,82 @@ def test_group_sql_clause():
     )
 
 
-def test_query_to_sql():
-    request_dict = {
-        "JobId": "88ca2cd8-0438-48ad-be14-dc9326b63234",
-        "Query": {
-            "Combinator": "AND",
-            "Groups": [
+def test_cohort_sql_clause():
+    and_group = {
+        "groups": [
+            {
+                "rules": [
+                    {
+                        "varname": "OMOP",
+                        "type": "TEXT",
+                        "oper": "=",
+                        "value": "8527",
+                    }
+                ],
+                "rules_oper": "OR",
+            },
+        ],
+        "groups_oper": "AND",
+    }
+    cohort = query.RQuestQueryCohort(**and_group)
+    # Assert single rule in single group builds correctly
+    assert str(cohort.sql_clause) == "race_concept_id = :race_concept_id_1"
+    and_group["groups"][0]["rules"].append(
+        {
+            "varname": "OMOP",
+            "type": "TEXT",
+            "oper": "=",
+            "value": "8532",
+        }
+    )
+    cohort = query.RQuestQueryCohort(**and_group)
+    # Assert multiple rules in single group build correctly
+    assert (
+        str(cohort.sql_clause)
+        == "gender_concept_id = :gender_concept_id_1 OR race_concept_id = :race_concept_id_1"
+    )
+    and_group["groups"].append(
+        {
+            "rules": [
                 {
-                    "Combinator": "OR",
-                    "Rules": [
-                        {
-                            "Type": "TEXT",
-                            "VariableName": "OMOP",
-                            "Operand": "=",
-                            "Value": "8527",
-                            "ExternalAttribute": "",
-                            "Unit": "",
-                            "RegEx": "",
-                        },
-                    ],
-                    "Exclude": False,
+                    "varname": "OMOP",
+                    "type": "TEXT",
+                    "oper": "=",
+                    "value": "8532",
                 }
             ],
+            "rules_oper": "OR",
+        }
+    )
+    # Assert multiple rules in multiple groups build correctly
+    cohort = query.RQuestQueryCohort(**and_group)
+    assert (
+        str(cohort.sql_clause)
+        == "(gender_concept_id = :gender_concept_id_1 OR race_concept_id = :race_concept_id_1) AND gender_concept_id = :gender_concept_id_2"
+    )
+
+
+def test_query_to_sql():
+    request_dict = {
+        "owner": "user1",
+        "cohort": {
+            "groups": [
+                {
+                    "rules": [
+                        {
+                            "varname": "OMOP",
+                            "type": "TEXT",
+                            "oper": "=",
+                            "value": "8527",
+                        }
+                    ],
+                    "rules_oper": "OR",
+                },
+            ],
+            "groups_oper": "AND",
         },
-        "ActivitySourceId": 1,
     }
-    test_query = query.RQuestQuery.from_dict(request_dict)
+    test_query = query.RQuestQuery(**request_dict)
     test_query_sql = test_query.to_sql()
     assert (
         str(test_query_sql)
@@ -192,18 +219,15 @@ FROM (SELECT DISTINCT person.person_id AS person_id
 FROM person JOIN condition_occurrence ON person.person_id = condition_occurrence.person_id JOIN measurement ON person.person_id = measurement.person_id JOIN observation ON person.person_id = observation.person_id 
 WHERE race_concept_id = :race_concept_id_1) AS anon_1"""
     )
-    request_dict["Query"]["Groups"][0]["Rules"].append(
+    request_dict["cohort"]["groups"][0]["rules"].append(
         {
-            "Type": "TEXT",
-            "VariableName": "OMOP",
-            "Operand": "=",
-            "Value": "8532",
-            "ExternalAttribute": "",
-            "Unit": "",
-            "RegEx": "",
+            "varname": "OMOP",
+            "type": "TEXT",
+            "oper": "=",
+            "value": "8532",
         }
     )
-    test_query = query.RQuestQuery.from_dict(request_dict)
+    test_query = query.RQuestQuery(**request_dict)
     test_query_sql = test_query.to_sql()
     assert (
         str(test_query_sql)
@@ -212,23 +236,20 @@ FROM (SELECT DISTINCT person.person_id AS person_id
 FROM person JOIN condition_occurrence ON person.person_id = condition_occurrence.person_id JOIN measurement ON person.person_id = measurement.person_id JOIN observation ON person.person_id = observation.person_id 
 WHERE gender_concept_id = :gender_concept_id_1 OR race_concept_id = :race_concept_id_1) AS anon_1"""
     )
-    request_dict["Query"]["Groups"].append(
+    request_dict["cohort"]["groups"].append(
         {
-            "Rules": [
+            "rules": [
                 {
-                    "Type": "TEXT",
-                    "VariableName": "OMOP",
-                    "Operand": "=",
-                    "Value": "8532",
-                    "ExternalAttribute": "",
-                    "Unit": "",
-                    "RegEx": "",
-                },
+                    "varname": "OMOP",
+                    "type": "TEXT",
+                    "oper": "=",
+                    "value": "8532",
+                }
             ],
-            "Combinator": "OR",
+            "rules_oper": "OR",
         }
     )
-    test_query = query.RQuestQuery.from_dict(request_dict)
+    test_query = query.RQuestQuery(**request_dict)
     test_query_sql = test_query.to_sql()
     assert (
         str(test_query_sql)

--- a/app/HutchAgent/tests/test_query.py
+++ b/app/HutchAgent/tests/test_query.py
@@ -1,44 +1,6 @@
 import pytest
 import hutchagent.query as query
 
-"""
-{
-    "job_id":"d21599d5-2514-4f63-9183-62ddc47f8e0d",
-    "cohort":{
-        "groups_oper":"OR",
-        "groups":[
-            {
-                "rules_oper":"AND",
-                "rules":[
-                    {
-                        "type":"TEXT",
-                        "varname":"OMOP",
-                        "oper":"=",
-                        "value":"8532",
-                        "time":"|6:TIME:M",
-                        "ext":"",
-                        "unit":"",
-                        "regex":""
-                    },
-                    {
-                        "type":"TEXT",
-                        "varname":"OMOP",
-                        "oper":"=",
-                        "value":"4139681",
-                        "time":"|18:AGE:Y",
-                        "ext":"",
-                        "unit":"",
-                        "regex":""
-                    }
-                ],
-                "exclude":false
-            }
-        ]
-    },
-    "activity_source_id":1
-}
-"""
-
 
 def test_create_rquest_query():
     request_dict = {
@@ -77,16 +39,12 @@ def test_create_rquest_query():
     assert isinstance(rquest_query.cohort.groups[0].rules[0], query.RQuestQueryRule)
 
 
-
 def test_text_rule_sql_clause():
     eq_rule = {
         "varname": "OMOP",
         "type": "TEXT",
         "oper": "=",
         "value": "8527",
-        "ext": "",
-        "unit": "",
-        "regex": "",
     }
     rule_obj = query.RQuestQueryRule(**eq_rule)
     assert rule_obj.concept_id == "8527"
@@ -97,7 +55,6 @@ def test_text_rule_sql_clause():
     assert str(rule_obj.sql_clause) == "race_concept_id != :race_concept_id_1"
 
 
-@pytest.mark.skip
 def test_numeric_rule_sql_clause():
     eq_rule = {
         "varname": "OMOP=8527",
@@ -120,7 +77,7 @@ def test_numeric_rule_sql_clause():
     )
 
 
-@pytest.mark.skip
+# @pytest.mark.skip
 def test_time_rule_sql_clause():
     eq_rule = {
         "varname": "OMOP",
@@ -154,7 +111,6 @@ def test_time_rule_sql_clause():
         print(rule_obj.sql_clause)
 
 
-@pytest.mark.skip
 def test_group_sql_clause():
     and_rule = {
         "rules": [
@@ -186,7 +142,6 @@ def test_group_sql_clause():
     )
 
 
-@pytest.mark.skip
 def test_cohort_sql_clause():
     and_group = {
         "groups": [
@@ -242,7 +197,6 @@ def test_cohort_sql_clause():
     )
 
 
-@pytest.mark.skip
 def test_query_to_sql():
     request_dict = {
         "owner": "user1",


### PR DESCRIPTION
## Overview

- Reverted #56
- Re-refactored RQuest query related classes in `HutchAgent/hutchagent/query.py`
- Recovers lost numeric and time rule functionality
- RQuest callback in `message_queue.py` accommodates new RQuest format and sends results to `api/results`

## Azure Boards

- [AB#67667](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/67667)
- [AB#67668](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/67668)
- [AB#67691](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/67691)
- [AB#67669](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/67669)
