### PR TITLE
AB#67849: Get the agent and the manager to use the same log db

### DIFF
--- a/app/HutchAgent/hutchagent/db_logging.py
+++ b/app/HutchAgent/hutchagent/db_logging.py
@@ -2,7 +2,6 @@ import datetime
 import argparse
 
 from logging import getLogger, Handler, LogRecord
-import os
 import dotenv
 
 from sqlalchemy import create_engine, Column, Integer, String, DateTime, Text, insert
@@ -16,8 +15,8 @@ dotenv.load_dotenv()
 Base = declarative_base()
 
 
-class Log(Base):
-    __tablename__ = os.getenv("LOG_TABLE_NAME")
+class Logs(Base):
+    __tablename__ = "Logs"  # this is required by sqlalchemy
     id = Column(Integer, primary_key=True, autoincrement=True)
     message = Column(Text, nullable=True)
     message_template = Column(Text, nullable=True)
@@ -53,7 +52,7 @@ class SyncLogDBHandler(Handler):
         else:
             exception = None
 
-        log_stmnt = insert(Log).values(
+        log_stmnt = insert(Logs).values(
             message=record.msg,
             level=record.levelname,
             exception=exception,
@@ -127,4 +126,4 @@ def create_log_table():
         database=args.database,
     )
     engine = create_engine(url=url)
-    Log.metadata.create_all(engine, checkfirst=True)
+    Logs.metadata.create_all(engine, checkfirst=True)

--- a/app/HutchAgent/hutchagent/db_logging.py
+++ b/app/HutchAgent/hutchagent/db_logging.py
@@ -21,7 +21,7 @@ class Logs(Base):
     exception = Column(Text, nullable=True)
     level = Column(String(128), nullable=True)
     message = Column(Text, nullable=True)
-    message_template = Column(Text, nullable=True)
+    messagetemplate = Column(Text, nullable=True)
     properties = Column(Text, nullable=True)
     timestamp = Column(DateTime, nullable=False, default=datetime.datetime.now)
 
@@ -56,7 +56,7 @@ class SyncLogDBHandler(Handler):
             message=record.msg,
             level=record.levelname,
             exception=exception,
-            message_template=self.formatter._fmt,
+            messagetemplate=self.formatter._fmt,
         )
 
         try:

--- a/app/HutchAgent/hutchagent/db_logging.py
+++ b/app/HutchAgent/hutchagent/db_logging.py
@@ -18,12 +18,12 @@ Base = declarative_base()
 class Logs(Base):
     __tablename__ = "Logs"  # this is required by sqlalchemy
     id = Column(Integer, primary_key=True, autoincrement=True)
+    exception = Column(Text, nullable=True)
+    level = Column(String(128), nullable=True)
     message = Column(Text, nullable=True)
     message_template = Column(Text, nullable=True)
-    level = Column(String(128), nullable=True)
-    timestamp = Column(DateTime, nullable=False, default=datetime.datetime.now)
-    exception = Column(Text, nullable=True)
     properties = Column(Text, nullable=True)
+    timestamp = Column(DateTime, nullable=False, default=datetime.datetime.now)
 
 
 class SyncLogDBHandler(Handler):

--- a/app/HutchAgent/tests/test_db_logging.py
+++ b/app/HutchAgent/tests/test_db_logging.py
@@ -6,7 +6,7 @@ import logging
 from sqlalchemy import create_engine, select
 from sqlalchemy.engine import URL
 
-from hutchagent.db_logging import Log, SyncLogDBHandler
+from hutchagent.db_logging import Logs, SyncLogDBHandler
 from hutchagent.db_manager import SyncDBManager
 
 
@@ -52,7 +52,7 @@ def spoof_db():
 
 def test_sync_db_logger(spoof_db):
     # create the log table
-    Log.metadata.create_all(spoof_db)
+    Logs.metadata.create_all(spoof_db)
 
     format = logging.Formatter(
         "%(levelname)s - %(asctime)s - %(message)s",
@@ -89,7 +89,7 @@ def test_sync_db_logger(spoof_db):
     db_logger.warning("This is a test.")
     db_logger.critical("This is a test.")
 
-    res = db_manager.execute_and_fetch(select(Log))
+    res = db_manager.execute_and_fetch(select(Logs))
     assert len(res) == len(
         expected_values
     ), "Did not retrieve the expected number of results"

--- a/app/HutchManager/Data/Entities/Logs.cs
+++ b/app/HutchManager/Data/Entities/Logs.cs
@@ -2,7 +2,6 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace HutchManager.Data.Entities;
 
-[Table("logs")]
 public class Logs
 {
   [Column("id")]
@@ -13,7 +12,7 @@ public class Logs
   public string Level { get; set; } = string.Empty;
   [Column("message")]
   public string Message { get; set; } = string.Empty;
-  [Column("messagetemplate")]
+  [Column("message_template")]
   public string MessageTemplate { get; set; } = string.Empty;
   [Column("properties")]
   public string Properties { get; set; } = string.Empty;

--- a/app/HutchManager/Data/Entities/Logs.cs
+++ b/app/HutchManager/Data/Entities/Logs.cs
@@ -12,7 +12,7 @@ public class Logs
   public string Level { get; set; } = string.Empty;
   [Column("message")]
   public string Message { get; set; } = string.Empty;
-  [Column("message_template")]
+  [Column("messagetemplate")]
   public string MessageTemplate { get; set; } = string.Empty;
   [Column("properties")]
   public string Properties { get; set; } = string.Empty;

--- a/app/HutchManager/Data/Migrations/20220715122118_20220715_rename_logs_to_Logs.Designer.cs
+++ b/app/HutchManager/Data/Migrations/20220715122118_20220715_rename_logs_to_Logs.Designer.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using HutchManager.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace HutchManager.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220715122118_20220715_rename_logs_to_Logs")]
+    partial class _20220715_rename_logs_to_Logs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/app/HutchManager/Data/Migrations/20220715122118_20220715_rename_logs_to_Logs.cs
+++ b/app/HutchManager/Data/Migrations/20220715122118_20220715_rename_logs_to_Logs.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HutchManager.Migrations
+{
+    public partial class _20220715_rename_logs_to_Logs : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_logs",
+                table: "logs");
+
+            migrationBuilder.RenameTable(
+                name: "logs",
+                newName: "Logs");
+
+            migrationBuilder.RenameColumn(
+                name: "messagetemplate",
+                table: "Logs",
+                newName: "message_template");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Logs",
+                table: "Logs",
+                column: "id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Logs",
+                table: "Logs");
+
+            migrationBuilder.RenameTable(
+                name: "Logs",
+                newName: "logs");
+
+            migrationBuilder.RenameColumn(
+                name: "message_template",
+                table: "logs",
+                newName: "messagetemplate");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_logs",
+                table: "logs",
+                column: "id");
+        }
+    }
+}

--- a/app/HutchManager/Data/Migrations/20220718113123_RemoveUnderScoreFromMessageTemplate.Designer.cs
+++ b/app/HutchManager/Data/Migrations/20220718113123_RemoveUnderScoreFromMessageTemplate.Designer.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using HutchManager.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace HutchManager.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220718113123_RemoveUnderScoreFromMessageTemplate")]
+    partial class RemoveUnderScoreFromMessageTemplate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/app/HutchManager/Data/Migrations/20220718113123_RemoveUnderScoreFromMessageTemplate.cs
+++ b/app/HutchManager/Data/Migrations/20220718113123_RemoveUnderScoreFromMessageTemplate.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HutchManager.Migrations
+{
+    public partial class RemoveUnderScoreFromMessageTemplate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "message_template",
+                table: "Logs",
+                newName: "messagetemplate");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "messagetemplate",
+                table: "Logs",
+                newName: "message_template");
+        }
+    }
+}

--- a/app/HutchManager/appsettings.Development.json
+++ b/app/HutchManager/appsettings.Development.json
@@ -12,7 +12,7 @@
         "Name": "PostgreSQL",
         "Args": {
           "connectionString": "Default",
-          "tableName": "logs",
+          "tableName": "Logs",
           "configurationPath": "ColumnsSectionHolder:AnotherSubSection",
           "useCopy": true,
           "respectCase": true


### PR DESCRIPTION
## Overview

- Make the names of the Logs table code match between the Manager and Agent.
- Make the order of columns match.
- Make migrations for the manager.
- Change the Serilog setting point to the new table name.

## Azure Boards

- [AB#67966](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/67966)
- [AB#67967](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/67967)
- [AB#67968](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/67968)
- [AB#67969](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/67969)
