### PR TITLE
AB#68119

### DIFF
--- a/app/HutchAgent/hutchagent/db_logging.py
+++ b/app/HutchAgent/hutchagent/db_logging.py
@@ -22,7 +22,7 @@ class Logs(Base):
     level = Column(String(128), nullable=True)
     message = Column(Text, nullable=True)
     messagetemplate = Column(Text, nullable=True)
-    properties = Column(Text, nullable=True)
+    properties = Column(Text, nullable=False, default="")
     timestamp = Column(DateTime, nullable=False, default=datetime.datetime.now)
 
 


### PR DESCRIPTION
## Overview

Correct agent DDL for log table. `Logs.properties` is now not nullable and defaults to an empty string.

## Azure Boards

- AB#68120
- AB#68121