### PR TITLE
AB#67952: ResultsModifier Bugfix

### DIFF
--- a/app/HutchManager/Services/ResultsModifierService.cs
+++ b/app/HutchManager/Services/ResultsModifierService.cs
@@ -20,7 +20,7 @@ public class ResultsModifierService
       .Include(x => x.Type)
       .Include(x => x.ActivitySource)
       .ToListAsync();
-    foreach (ResultsModifier r in list )
+    foreach (ResultsModifier r in list)
     {
       r.ActivitySource = await _db.ActivitySources
                            .AsNoTracking()

--- a/app/HutchManager/Services/ResultsModifierService.cs
+++ b/app/HutchManager/Services/ResultsModifierService.cs
@@ -20,6 +20,16 @@ public class ResultsModifierService
       .Include(x => x.Type)
       .Include(x => x.ActivitySource)
       .ToListAsync();
+    foreach (ResultsModifier r in list )
+    {
+      r.ActivitySource = await _db.ActivitySources
+                           .AsNoTracking()
+                           .Include(x => x.Type)
+                           .Include(x => x.TargetDataSource)
+                           .SingleOrDefaultAsync(x => x.Id == r.ActivitySource.Id)
+                         ?? throw new KeyNotFoundException();
+    }
+
     return list.ConvertAll<Models.ResultsModifierModel>(x => new(x));
   }
 

--- a/app/HutchManager/Services/ResultsModifierService.cs
+++ b/app/HutchManager/Services/ResultsModifierService.cs
@@ -19,17 +19,10 @@ public class ResultsModifierService
       .AsNoTracking()
       .Include(x => x.Type)
       .Include(x => x.ActivitySource)
+        .ThenInclude(x => x.Type)
+      .Include(x => x.ActivitySource)
+        .ThenInclude(x => x.TargetDataSource)
       .ToListAsync();
-    foreach (ResultsModifier r in list)
-    {
-      r.ActivitySource = await _db.ActivitySources
-                           .AsNoTracking()
-                           .Include(x => x.Type)
-                           .Include(x => x.TargetDataSource)
-                           .SingleOrDefaultAsync(x => x.Id == r.ActivitySource.Id)
-                         ?? throw new KeyNotFoundException();
-    }
-
     return list.ConvertAll<Models.ResultsModifierModel>(x => new(x));
   }
 

--- a/app/manager-frontend/src/components/ConfigureResultsModifierModal.jsx
+++ b/app/manager-frontend/src/components/ConfigureResultsModifierModal.jsx
@@ -262,7 +262,7 @@ export const ConfigureResultsModifierModal = ({
                       label: item.id,
                     }))}
                     sourceList={typeOptions}
-                    sourceParam="id"
+                    sourceKey="id"
                   />
                   <FormikSelect
                     label="Activity Source"
@@ -273,7 +273,7 @@ export const ConfigureResultsModifierModal = ({
                       label: item.displayName,
                     }))}
                     sourceList={activitySourceOptions}
-                    sourceParam="id"
+                    sourceKey="id"
                   />
                   <LowNumberSuppressionParameters type={values.Type} />
                   <Button

--- a/app/manager-frontend/src/components/ConfigureResultsModifierModal.jsx
+++ b/app/manager-frontend/src/components/ConfigureResultsModifierModal.jsx
@@ -197,8 +197,7 @@ export const ConfigureResultsModifierModal = ({
       await action({
         values: {
           ...payload,
-          ActivitySourceId: payload.ActivitySource.id,
-          Type: payload.Type.id,
+          ActivitySourceId: payload.ActivitySource,
         },
         id: initialData ? initialData.id : undefined,
       }).json();
@@ -229,16 +228,16 @@ export const ConfigureResultsModifierModal = ({
               initialData
                 ? {
                     Order: initialData.order,
-                    Type: initialData.type,
+                    Type: initialData.type.id,
                     // capitalise the object keys in the parameters object
                     Parameters: capitaliseObjectKeys(initialData.parameters),
-                    ActivitySource: initialData.activitySource,
+                    ActivitySource: initialData.activitySource.id,
                   }
                 : {
                     Order: "0",
-                    Type: typeOptions[0],
+                    Type: typeOptions[0].id,
                     Parameters: {},
-                    ActivitySource: activitySourceOptions[0],
+                    ActivitySource: activitySourceOptions[0].id,
                   }
             }
             validationSchema={validationSchema()}
@@ -261,8 +260,6 @@ export const ConfigureResultsModifierModal = ({
                       value: item.id,
                       label: item.id,
                     }))}
-                    sourceList={typeOptions}
-                    sourceKey="id"
                   />
                   <FormikSelect
                     label="Activity Source"
@@ -272,8 +269,6 @@ export const ConfigureResultsModifierModal = ({
                       value: item.id,
                       label: item.displayName,
                     }))}
-                    sourceList={activitySourceOptions}
-                    sourceKey="id"
                   />
                   <LowNumberSuppressionParameters type={values.Type} />
                   <Button
@@ -293,7 +288,13 @@ export const ConfigureResultsModifierModal = ({
                     isOpen={isConfirmOpen}
                     onClose={onConfirmClose}
                     initialData={initialData}
-                    newData={values}
+                    newData={{
+                      ...values,
+                      ActivitySource: activitySourceOptions.find(
+                        (item) => item.id == values.ActivitySource
+                      ),
+                      Type: typeOptions.find((item) => item.id == values.Type),
+                    }}
                   />
                 </VStack>
               </Form>

--- a/app/manager-frontend/src/components/ConfigureResultsModifierModal.jsx
+++ b/app/manager-frontend/src/components/ConfigureResultsModifierModal.jsx
@@ -229,14 +229,14 @@ export const ConfigureResultsModifierModal = ({
               initialData
                 ? {
                     Order: initialData.order,
-                    Type: initialData.type.id,
+                    Type: initialData.type,
                     // capitalise the object keys in the parameters object
                     Parameters: capitaliseObjectKeys(initialData.parameters),
                     ActivitySource: initialData.activitySource,
                   }
                 : {
                     Order: "0",
-                    Type: typeOptions[0].id,
+                    Type: typeOptions[0],
                     Parameters: {},
                     ActivitySource: activitySourceOptions[0],
                   }

--- a/app/manager-frontend/src/components/forms/FormikSelect.jsx
+++ b/app/manager-frontend/src/components/forms/FormikSelect.jsx
@@ -25,13 +25,25 @@ export const FormikSelect = ({
   tooltip,
   alert,
   hasEmptyDefault,
+  sourceList,
+  sourceKey,
 }) => {
   const [field, meta, helpers] = useField({ name, type: "select" });
-  const [value, setValue] = useState(field.value);
+  const initialValue =
+    sourceList && sourceKey && typeof field.value === "object"
+      ? sourceList.find((item) => item[sourceKey] == field.value[sourceKey])[
+          sourceKey
+        ]
+      : field.value;
+  const [value, setValue] = useState(initialValue);
 
   const handleChange = ({ target: { value } }) => {
+    let formikValue = value;
+    if (sourceList && sourceKey) {
+      formikValue = sourceList.find((item) => item[sourceKey] == value);
+    }
     setValue(value);
-    helpers.setValue(value);
+    helpers.setValue(formikValue);
   };
 
   return (

--- a/app/manager-frontend/src/components/forms/FormikSelect.jsx
+++ b/app/manager-frontend/src/components/forms/FormikSelect.jsx
@@ -25,25 +25,13 @@ export const FormikSelect = ({
   tooltip,
   alert,
   hasEmptyDefault,
-  sourceList,
-  sourceKey,
 }) => {
   const [field, meta, helpers] = useField({ name, type: "select" });
-  const initialValue =
-    sourceList && sourceKey && typeof field.value === "object"
-      ? sourceList.find((item) => item[sourceKey] == field.value[sourceKey])[
-          sourceKey
-        ]
-      : field.value;
-  const [value, setValue] = useState(initialValue);
+  const [value, setValue] = useState(field.value);
 
   const handleChange = ({ target: { value } }) => {
-    let formikValue = value;
-    if (sourceList && sourceKey) {
-      formikValue = sourceList.find((item) => item[sourceKey] == value);
-    }
     setValue(value);
-    helpers.setValue(formikValue);
+    helpers.setValue(value);
   };
 
   return (


### PR DESCRIPTION
## Overview

Fixed results modifier functionality on the frontend with formikSelect.

## Bug description
- Error was being thrown when trying to convert activity source entity from results modifier to an activity source model because the type was not being included. Now fixed by including type for results modifier activity sources
- formik values of Activity Source and Type in formikSelect were being set as string values instead of objects which was causing a bug in displaying the changes when editing those values and in submitting those values. Fixed by editing formikSelect to be able to handle objects

## Azure Boards

- [AB#67952](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/67952)
