### PR TITLE
AB#62642: Internal Query Agent - joining to more OMOP tables

### DIFF
--- a/app/HutchAgent/hutchagent/entities.py
+++ b/app/HutchAgent/hutchagent/entities.py
@@ -7,78 +7,125 @@ from sqlalchemy import (
     Numeric,
     String,
     DateTime,
+    Text,
 )
 from sqlalchemy.ext.declarative import declarative_base
 
 Base = declarative_base()
 
 
+class Concept(Base):
+    __tablename__ = "concept"
+    concept_id = Column(Integer, primary_key=True)
+    concept_name = Column(String(255), nullable=False)
+    domain_id = Column(String(20), nullable=False)
+    vocabulary_id = Column(String(20), nullable=False)
+    concept_class_id = Column(String(20), nullable=False)
+    standard_concept = Column(String(1), nullable=True)
+    concept_code = Column(String(50), nullable=False)
+    valid_start_date = Column(Date, nullable=False)
+    valid_end_date = Column(Date, nullable=False)
+    invalid_reason = Column(String(1), nullable=True)
+
+
 class Person(Base):
     __tablename__ = "person"
     person_id = Column(Integer, primary_key=True)
-    gender_concept_id = Column(Integer, nullable=False)
+    gender_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=False
+    )
     year_of_birth = Column(Integer, nullable=False)
     month_of_birth = Column(Integer, nullable=True)
     day_of_birth = Column(Integer, nullable=True)
     birth_datetime = Column(DateTime, nullable=True)
-    race_concept_id = Column(Integer, nullable=False)
-    ethnicity_concept_id = Column(Integer, nullable=False)
+    race_concept_id = Column(Integer, ForeignKey("concept.concept_id"), nullable=False)
+    ethnicity_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=False
+    )
     location_id = Column(Integer, nullable=True)
     provider_id = Column(Integer, nullable=True)
     care_site_id = Column(Integer, nullable=True)
     person_source_value = Column(String(50), nullable=True)
     gender_source_value = Column(String(50), nullable=True)
-    gender_source_concept_id = Column(Integer, nullable=True)
+    gender_source_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=True
+    )
     race_source_value = Column(String(50), nullable=True)
-    race_source_concept_id = Column(Integer, nullable=True)
+    race_source_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=True
+    )
     ethnicity_source_value = Column(String(50), nullable=True)
-    ethnicity_source_concept_id = Column(Integer, nullable=True)
+    ethnicity_source_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=True
+    )
 
 
 class Measurement(Base):
     __tablename__ = "measurement"
     measurement_id = Column(Integer, primary_key=True)
     person_id = Column(Integer, ForeignKey("person.person_id"), nullable=False)
-    measurement_concept_id = Column(Integer, nullable=False)
+    measurement_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=False
+    )
     measurement_date = Column(Date, nullable=False)
     measurement_datetime = Column(DateTime, nullable=True)
     measurement_time = Column(String(10), nullable=True)
-    measurement_type_concept_id = Column(Integer, nullable=False)
-    operator_concept_id = Column(Integer, nullable=True)
+    measurement_type_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=False
+    )
+    operator_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=True
+    )
     value_as_number = Column(Numeric, nullable=True)
-    value_as_concept_id = Column(Integer, nullable=True)
-    unit_concept_id = Column(Integer, nullable=True)
+    value_as_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=True
+    )
+    unit_concept_id = Column(Integer, ForeignKey("concept.concept_id"), nullable=True)
     range_low = Column(Numeric, nullable=True)
     range_high = Column(Numeric, nullable=True)
     provider_id = Column(Integer, nullable=True)
     visit_occurrence_id = Column(Integer, nullable=True)
     visit_detail_id = Column(Integer, nullable=True)
     measurement_source_value = Column(String(50), nullable=True)
-    measurement_source_concept_id = Column(Integer, nullable=True)
+    measurement_source_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=True
+    )
     unit_source_value = Column(String(50), nullable=True)
-    unit_source_concept_id = Column(Integer, nullable=True)
+    unit_source_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=True
+    )
     value_source_value = Column(String(50), nullable=True)
     measurement_event_id = Column(BigInteger, nullable=True)
-    meas_event_field_concept_id = Column(Integer, nullable=True)
+    meas_event_field_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=True
+    )
 
 
 class ConditionOccurrence(Base):
     __tablename__ = "condition_occurrence"
     condition_occurrence_id = Column(Integer, primary_key=True)
     person_id = Column(Integer, ForeignKey("person.person_id"), nullable=False)
-    condition_concept_id = Column(Integer, nullable=False)
+    condition_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=False
+    )
     condition_start_date = Column(Date, nullable=False)
     condition_start_datetime = Column(DateTime, nullable=True)
     condition_end_date = Column(Date, nullable=True)
     condition_end_datetime = Column(DateTime, nullable=True)
-    condition_type_concept_id = Column(Integer, nullable=False)
-    condition_status_concept_id = Column(Integer, nullable=True)
+    condition_type_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=False
+    )
+    condition_status_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=True
+    )
     stop_reason = Column(String(20), nullable=True)
     provider_id = Column(Integer, nullable=True)
     visit_occurrence_id = Column(Integer, nullable=True)
     visit_detail_id = Column(Integer, nullable=True)
     condition_source_value = Column(String(50), nullable=True)
-    condition_source_concept_id = Column(Integer, nullable=True)
+    condition_source_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=True
+    )
     condition_status_source_value = Column(String(50), nullable=True)
 
 
@@ -86,22 +133,93 @@ class Observation(Base):
     __tablename__ = "observation"
     observation_id = Column(Integer, primary_key=True)
     person_id = Column(Integer, ForeignKey("person.person_id"), nullable=False)
-    observation_concept_id = Column(Integer, nullable=False)
+    observation_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=False
+    )
     observation_date = Column(Date, nullable=False)
     observation_datetime = Column(DateTime, nullable=True)
-    observation_type_concept_id = Column(Integer, nullable=False)
+    observation_type_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=False
+    )
     value_as_number = Column(Numeric, nullable=True)
     value_as_string = Column(String(60), nullable=True)
-    value_as_concept_id = Column(Integer, nullable=True)
-    qualifier_concept_id = Column(Integer, nullable=True)
-    unit_concept_id = Column(Integer, nullable=True)
+    value_as_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=True
+    )
+    qualifier_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=True
+    )
+    unit_concept_id = Column(Integer, ForeignKey("concept.concept_id"), nullable=True)
     provider_id = Column(Integer, nullable=True)
     visit_occurrence_id = Column(Integer, nullable=True)
     visit_detail_id = Column(Integer, nullable=True)
     observation_source_value = Column(String(50), nullable=True)
-    observation_source_concept_id = Column(Integer, nullable=True)
+    observation_source_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=True
+    )
     unit_source_value = Column(String(50), nullable=True)
     qualifier_source_value = Column(String(50), nullable=True)
     value_source_value = Column(String(50), nullable=True)
     observation_event_id = Column(BigInteger, nullable=True)
-    obs_event_field_concept_id = Column(Integer, nullable=True)
+    obs_event_field_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=True
+    )
+
+
+class ProcedureOccurrence(Base):
+    __tablename__ = "procedure_occurrence"
+    procedure_occurrence_id = Column(Integer, primary_key=True)
+    person_id = Column(Integer, ForeignKey("person.person_id"), nullable=False)
+    procedure_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=False
+    )
+    procedure_date = Column(Date, nullable=False)
+    procedure_datetime = Column(DateTime, nullable=True)
+    procedure_end_date = Column(Date, nullable=True)
+    procedure_end_datetime = Column(DateTime, nullable=True)
+    procedure_type_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=False
+    )
+    modifier_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=True
+    )
+    quantity = Column(Integer, nullable=True)
+    provider_id = Column(Integer, nullable=True)
+    visit_occurrence_id = Column(Integer, nullable=True)
+    visit_detail_id = Column(Integer, nullable=True)
+    procedure_source_value = Column(String(50), nullable=True)
+    procedure_source_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=True
+    )
+    modifier_source_value = Column(String(50), nullable=True)
+
+
+class DrugExposure(Base):
+    __tablename__ = "drug_exposure"
+    drug_exposure_id = Column(Integer, primary_key=True)
+    person_id = Column(Integer, ForeignKey("person.person_id"), nullable=False)
+    drug_concept_id = Column(Integer, ForeignKey("concept.concept_id"), nullable=False)
+    drug_exposure_start_date = Column(Date, nullable=False)
+    drug_exposure_start_datetime = Column(DateTime, nullable=True)
+    drug_exposure_end_date = Column(Date, nullable=False)
+    drug_exposure_end_datetime = Column(DateTime, nullable=True)
+    verbatim_end_date = Column(Date, nullable=True)
+    drug_type_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=False
+    )
+    stop_reason = Column(String(20), nullable=True)
+    refills = Column(Integer, nullable=True)
+    quantity = Column(Numeric, nullable=True)
+    days_supply = Column(Integer, nullable=True)
+    sig = Column(Text, nullable=True)
+    route_concept_id = Column(Integer, ForeignKey("concept.concept_id"), nullable=True)
+    lot_number = Column(String(50), nullable=True)
+    provider_id = Column(Integer, nullable=True)
+    visit_occurrence_id = Column(Integer, nullable=True)
+    visit_detail_id = Column(Integer, nullable=True)
+    drug_source_value = Column(String(50), nullable=True)
+    drug_source_concept_id = Column(
+        Integer, ForeignKey("concept.concept_id"), nullable=True
+    )
+    route_source_value = Column(String(50), nullable=True)
+    dose_unit_source_value = Column(String(50), nullable=True)

--- a/app/HutchAgent/hutchagent/message_queue.py
+++ b/app/HutchAgent/hutchagent/message_queue.py
@@ -12,7 +12,7 @@ import hutchagent.config as config
 from hutchagent.ro_crates.result import Result
 from hutchagent.ro_crates.query import Query
 from hutchagent.db_manager import SyncDBManager
-from hutchagent.query import RQuestQuery
+from hutchagent.query import RQuestQuery, RQuestQueryBuilder, ROCratesQueryBuilder
 
 
 def connect(queue: str, host="localhost", **kwargs) -> BlockingChannel:
@@ -81,9 +81,11 @@ def rquest_callback(
         drivername=os.getenv("DATASOURCE_DB_DRIVERNAME", config.DEFAULT_DB_DRIVER),
         schema=os.getenv("DATASOURCE_DB_SCHEMA"),
     )
+    query_builder = RQuestQueryBuilder(db_manager, query)
+    query_builder.build_subqueries()
     try:
         query_start = time.time()
-        res = db_manager.execute_and_fetch(query.to_sql())
+        res = db_manager.execute_and_fetch(query_builder.build_sql())
         query_end = time.time()
         count_ = res[0][0]
         response_data["queryResult"].update(count=count_)
@@ -151,9 +153,11 @@ def ro_crates_callback(
         drivername=os.getenv("DATASOURCE_DB_DRIVERNAME", config.DEFAULT_DB_DRIVER),
         schema=os.getenv("DATASOURCE_DB_SCHEMA"),
     )
+    query_builder = ROCratesQueryBuilder(db_manager, query)
+    query_builder.build_subqueries()
     try:
         query_start = time.time()
-        res = db_manager.execute_and_fetch(query.to_sql())
+        res = db_manager.execute_and_fetch(query_builder.build_sql())
         query_end = time.time()
         count_ = res[0][0]
         logger.info(

--- a/app/HutchAgent/hutchagent/query.py
+++ b/app/HutchAgent/hutchagent/query.py
@@ -357,22 +357,22 @@ class RQuestQueryBuilder(BaseQueryBuilder):
                         .join(
                             ProcedureOccurrence,
                             Person.person_id == ProcedureOccurrence.person_id,
-                            isouter=True,
+                            full=True,
                         )
                         .join(
                             ConditionOccurrence,
                             Person.person_id == ConditionOccurrence.person_id,
-                            isouter=True,
+                            full=True,
                         )
                         .join(
                             Observation,
                             Person.person_id == Observation.person_id,
-                            isouter=True,
+                            full=True,
                         )
                         .join(
                             DrugExposure,
                             Person.person_id == DrugExposure.person_id,
-                            isouter=True,
+                            full=True,
                         )
                         .where(
                             or_(
@@ -395,22 +395,22 @@ class RQuestQueryBuilder(BaseQueryBuilder):
                         .join(
                             ProcedureOccurrence,
                             Person.person_id == ProcedureOccurrence.person_id,
-                            isouter=True,
+                            full=True,
                         )
                         .join(
                             ConditionOccurrence,
                             Person.person_id == ConditionOccurrence.person_id,
-                            isouter=True,
+                            full=True,
                         )
                         .join(
                             Observation,
                             Person.person_id == Observation.person_id,
-                            isouter=True,
+                            full=True,
                         )
                         .join(
                             DrugExposure,
                             Person.person_id == DrugExposure.person_id,
-                            isouter=True,
+                            full=True,
                         )
                         .where(
                             or_(
@@ -444,7 +444,7 @@ class RQuestQueryBuilder(BaseQueryBuilder):
         """Build and return the final SQL that can be used to query the database."""
         stmnt = select(func.count()).select_from(self.subqueries[0])
         for sq in self.subqueries[1:]:
-            stmnt = stmnt.join(sq, isouter=True)
+            stmnt = stmnt.join(sq)
         self.subqueries.clear()
         return stmnt
 
@@ -466,22 +466,22 @@ class ROCratesQueryBuilder(BaseQueryBuilder):
                         .join(
                             ProcedureOccurrence,
                             Person.person_id == ProcedureOccurrence.person_id,
-                            isouter=True,
+                            full=True,
                         )
                         .join(
                             ConditionOccurrence,
                             Person.person_id == ConditionOccurrence.person_id,
-                            isouter=True,
+                            full=True,
                         )
                         .join(
                             Observation,
                             Person.person_id == Observation.person_id,
-                            isouter=True,
+                            full=True,
                         )
                         .join(
                             DrugExposure,
                             Person.person_id == DrugExposure.person_id,
-                            isouter=True,
+                            full=True,
                         )
                         .where(
                             or_(
@@ -504,22 +504,22 @@ class ROCratesQueryBuilder(BaseQueryBuilder):
                         .join(
                             ProcedureOccurrence,
                             Person.person_id == ProcedureOccurrence.person_id,
-                            isouter=True,
+                            full=True,
                         )
                         .join(
                             ConditionOccurrence,
                             Person.person_id == ConditionOccurrence.person_id,
-                            isouter=True,
+                            full=True,
                         )
                         .join(
                             Observation,
                             Person.person_id == Observation.person_id,
-                            isouter=True,
+                            full=True,
                         )
                         .join(
                             DrugExposure,
                             Person.person_id == DrugExposure.person_id,
-                            isouter=True,
+                            full=True,
                         )
                         .where(
                             or_(
@@ -553,6 +553,6 @@ class ROCratesQueryBuilder(BaseQueryBuilder):
         """Build and return the final SQL that can be used to query the database."""
         stmnt = select(func.count()).select_from(self.subqueries[0])
         for sq in self.subqueries[1:]:
-            stmnt = stmnt.join(sq, isouter=True)
+            stmnt = stmnt.join(sq)
         self.subqueries.clear()
         return stmnt

--- a/app/HutchAgent/hutchagent/query.py
+++ b/app/HutchAgent/hutchagent/query.py
@@ -461,6 +461,7 @@ class RQuestQueryBuilder(BaseQueryBuilder):
                                 Measurement.value_as_number.between(*group.rules[i].value)
                             )
                         )
+                        .distinct()
                         .subquery()
                     )
                     stmnt = stmnt.join(
@@ -472,10 +473,11 @@ class RQuestQueryBuilder(BaseQueryBuilder):
 
     def build_sql(self) -> sql.selectable.Select:
         """Build and return the final SQL that can be used to query the database."""
-        stmnt = select(func.count()).select_from(self.subqueries[0])
+        group_stmnt = self.subqueries[0]
         for sq in self.subqueries[1:]:
-            stmnt = stmnt.join(sq)
+            group_stmnt = group_stmnt.join(sq, full=self.query.cohort.groups_oper == "OR")
         self.subqueries.clear()
+        stmnt = select(func.count()).select_from(group_stmnt)
         return stmnt
 
 

--- a/app/HutchAgent/hutchagent/query.py
+++ b/app/HutchAgent/hutchagent/query.py
@@ -212,8 +212,6 @@ class RQuestQueryGroup:
         self.rules = (
             [RQuestQueryRule(**r) for r in rules] if rules is not None else list()
         )
-        # Sort rules for more predictable behaviour in tests.
-        self.rules = sorted(self.rules, key=lambda x: x.column_name)
         self.rules_oper = rules_oper
         self.exclude = exclude
 

--- a/app/HutchAgent/hutchagent/query.py
+++ b/app/HutchAgent/hutchagent/query.py
@@ -485,13 +485,13 @@ class ROCratesQueryBuilder(BaseQueryBuilder):
                         )
                         .where(
                             or_(
-                                Person.ethnicity_concept_id == rule.concept_id,
-                                Person.gender_concept_id == rule.concept_id,
-                                Person.race_concept_id == rule.concept_id,
-                                ProcedureOccurrence.procedure_concept_id == rule.concept_id,
-                                ConditionOccurrence.condition_concept_id == rule.concept_id,
-                                Observation.observation_concept_id == rule.concept_id,
-                                DrugExposure.drug_concept_id == rule.concept_id,
+                                Person.ethnicity_concept_id == rule.name,
+                                Person.gender_concept_id == rule.name,
+                                Person.race_concept_id == rule.name,
+                                ProcedureOccurrence.procedure_concept_id == rule.name,
+                                ConditionOccurrence.condition_concept_id == rule.name,
+                                Observation.observation_concept_id == rule.name,
+                                DrugExposure.drug_concept_id == rule.name,
                             )
                         )
                         .distinct()
@@ -523,13 +523,13 @@ class ROCratesQueryBuilder(BaseQueryBuilder):
                         )
                         .where(
                             or_(
-                                Person.ethnicity_concept_id != rule.concept_id,
-                                Person.gender_concept_id != rule.concept_id,
-                                Person.race_concept_id != rule.concept_id,
-                                ProcedureOccurrence.procedure_concept_id != rule.concept_id,
-                                ConditionOccurrence.condition_concept_id != rule.concept_id,
-                                Observation.observation_concept_id != rule.concept_id,
-                                DrugExposure.drug_concept_id != rule.concept_id,
+                                Person.ethnicity_concept_id != rule.name,
+                                Person.gender_concept_id != rule.name,
+                                Person.race_concept_id != rule.name,
+                                ProcedureOccurrence.procedure_concept_id != rule.name,
+                                ConditionOccurrence.condition_concept_id != rule.name,
+                                Observation.observation_concept_id != rule.name,
+                                DrugExposure.drug_concept_id != rule.name,
                             )
                         )
                         .distinct()
@@ -541,7 +541,7 @@ class ROCratesQueryBuilder(BaseQueryBuilder):
                         select(Measurement.person_id)
                         .where(
                             and_(
-                                Measurement.measurement_concept_id == rule.concept_id,
+                                Measurement.measurement_concept_id == rule.name,
                                 Measurement.value_as_number.between(rule.min_value, rule.max_value)
                             )
                         )

--- a/app/HutchAgent/hutchagent/query.py
+++ b/app/HutchAgent/hutchagent/query.py
@@ -56,6 +56,9 @@ class RQuestQueryRule:
         self.ext = ext
         self.regex = regex
         self.unit = unit
+        # Set these with `set_table` and `set_column`
+        self.table = None
+        self.column = None
 
     def _parse_value(self, value: str) -> Any:
         """Parse string value into correct type.
@@ -188,6 +191,14 @@ class RQuestQueryRule:
             raise ValueError(
                 f"Could not parse the time value ({self.time_}) in the rule."
             )
+
+    def set_table(self, table):
+        """Set the table for the rule."""
+        self.table = table
+
+    def set_column(self, column):
+        """Set the column for the rule"""
+        self.column = column
 
 
 class RQuestQueryGroup:

--- a/app/HutchAgent/hutchagent/query.py
+++ b/app/HutchAgent/hutchagent/query.py
@@ -479,6 +479,34 @@ class ROCratesQueryBuilder(BaseQueryBuilder):
                             )
                         )
                         .distinct()
+                        .join(
+                            select(ProcedureOccurrence.person_id)
+                            .where(ProcedureOccurrence.procedure_concept_id == rule.concept_id)
+                            .distinct()
+                            .subquery(),
+                            isouter=True
+                        )
+                        .join(
+                            select(ConditionOccurrence.person_id)
+                            .where(ConditionOccurrence.condition_concept_id == rule.concept_id)
+                            .distinct()
+                            .subquery(),
+                            isouter=True
+                        )
+                        .join(
+                            select(Observation.person_id)
+                            .where(Observation.observation_concept_id == rule.concept_id)
+                            .distinct()
+                            .subquery(),
+                            isouter=True
+                        )
+                        .join(
+                            select(DrugExposure.person_id)
+                            .where(DrugExposure.drug_concept_id == rule.concept_id)
+                            .distinct()
+                            .subquery(),
+                            isouter=True
+                        )
                         .subquery()
                     )
                 # Text rules testing for exclusion
@@ -493,6 +521,34 @@ class ROCratesQueryBuilder(BaseQueryBuilder):
                             )
                         )
                         .distinct()
+                        .join(
+                            select(ProcedureOccurrence.person_id)
+                            .where(ProcedureOccurrence.procedure_concept_id != rule.concept_id)
+                            .distinct()
+                            .subquery(),
+                            isouter=True
+                        )
+                        .join(
+                            select(ConditionOccurrence.person_id)
+                            .where(ConditionOccurrence.condition_concept_id != rule.concept_id)
+                            .distinct()
+                            .subquery(),
+                            isouter=True
+                        )
+                        .join(
+                            select(Observation.person_id)
+                            .where(Observation.observation_concept_id != rule.concept_id)
+                            .distinct()
+                            .subquery(),
+                            isouter=True
+                        )
+                        .join(
+                            select(DrugExposure.person_id)
+                            .where(DrugExposure.drug_concept_id != rule.concept_id)
+                            .distinct()
+                            .subquery(),
+                            isouter=True
+                        )
                         .subquery()
                     )
                 else:

--- a/app/HutchAgent/hutchagent/query.py
+++ b/app/HutchAgent/hutchagent/query.py
@@ -354,84 +354,76 @@ class RQuestQueryBuilder(BaseQueryBuilder):
                 if rule.type == "TEXT" and rule.oper == "=":
                     self.subqueries.append(
                         select(Person.person_id)
+                        .join(
+                            ProcedureOccurrence,
+                            Person.person_id == ProcedureOccurrence.person_id,
+                            isouter=True,
+                        )
+                        .join(
+                            ConditionOccurrence,
+                            Person.person_id == ConditionOccurrence.person_id,
+                            isouter=True,
+                        )
+                        .join(
+                            Observation,
+                            Person.person_id == Observation.person_id,
+                            isouter=True,
+                        )
+                        .join(
+                            DrugExposure,
+                            Person.person_id == DrugExposure.person_id,
+                            isouter=True,
+                        )
                         .where(
                             or_(
                                 Person.ethnicity_concept_id == rule.concept_id,
                                 Person.gender_concept_id == rule.concept_id,
                                 Person.race_concept_id == rule.concept_id,
+                                ProcedureOccurrence.procedure_concept_id == rule.concept_id,
+                                ConditionOccurrence.condition_concept_id == rule.concept_id,
+                                Observation.observation_concept_id == rule.concept_id,
+                                DrugExposure.drug_concept_id == rule.concept_id,
                             )
                         )
                         .distinct()
-                        .join(
-                            select(ProcedureOccurrence.person_id)
-                            .where(ProcedureOccurrence.procedure_concept_id == rule.concept_id)
-                            .distinct()
-                            .subquery(),
-                            isouter=True
-                        )
-                        .join(
-                            select(ConditionOccurrence.person_id)
-                            .where(ConditionOccurrence.condition_concept_id == rule.concept_id)
-                            .distinct()
-                            .subquery(),
-                            isouter=True
-                        )
-                        .join(
-                            select(Observation.person_id)
-                            .where(Observation.observation_concept_id == rule.concept_id)
-                            .distinct()
-                            .subquery(),
-                            isouter=True
-                        )
-                        .join(
-                            select(DrugExposure.person_id)
-                            .where(DrugExposure.drug_concept_id == rule.concept_id)
-                            .distinct()
-                            .subquery(),
-                            isouter=True
-                        )
                         .subquery()
                     )
                 # Text rules testing for exclusion
                 elif rule.type == "TEXT" and rule.oper == "!=":
                     self.subqueries.append(
                         select(Person.person_id)
+                        .join(
+                            ProcedureOccurrence,
+                            Person.person_id == ProcedureOccurrence.person_id,
+                            isouter=True,
+                        )
+                        .join(
+                            ConditionOccurrence,
+                            Person.person_id == ConditionOccurrence.person_id,
+                            isouter=True,
+                        )
+                        .join(
+                            Observation,
+                            Person.person_id == Observation.person_id,
+                            isouter=True,
+                        )
+                        .join(
+                            DrugExposure,
+                            Person.person_id == DrugExposure.person_id,
+                            isouter=True,
+                        )
                         .where(
                             or_(
                                 Person.ethnicity_concept_id != rule.concept_id,
                                 Person.gender_concept_id != rule.concept_id,
                                 Person.race_concept_id != rule.concept_id,
+                                ProcedureOccurrence.procedure_concept_id != rule.concept_id,
+                                ConditionOccurrence.condition_concept_id != rule.concept_id,
+                                Observation.observation_concept_id != rule.concept_id,
+                                DrugExposure.drug_concept_id != rule.concept_id,
                             )
                         )
                         .distinct()
-                        .join(
-                            select(ProcedureOccurrence.person_id)
-                            .where(ProcedureOccurrence.procedure_concept_id != rule.concept_id)
-                            .distinct()
-                            .subquery(),
-                            isouter=True
-                        )
-                        .join(
-                            select(ConditionOccurrence.person_id)
-                            .where(ConditionOccurrence.condition_concept_id != rule.concept_id)
-                            .distinct()
-                            .subquery(),
-                            isouter=True
-                        )
-                        .join(
-                            select(Observation.person_id)
-                            .where(Observation.observation_concept_id != rule.concept_id)
-                            .distinct()
-                            .subquery(),
-                            isouter=True
-                        )
-                        .join(
-                            select(DrugExposure.person_id)
-                            .where(DrugExposure.drug_concept_id != rule.concept_id)
-                            .distinct()
-                            .subquery(),
-                            isouter=True
-                        )
                         .subquery()
                     )
                 else:

--- a/app/HutchAgent/hutchagent/query.py
+++ b/app/HutchAgent/hutchagent/query.py
@@ -362,6 +362,34 @@ class RQuestQueryBuilder(BaseQueryBuilder):
                             )
                         )
                         .distinct()
+                        .join(
+                            select(ProcedureOccurrence.person_id)
+                            .where(ProcedureOccurrence.procedure_concept_id == rule.concept_id)
+                            .distinct()
+                            .subquery(),
+                            isouter=True
+                        )
+                        .join(
+                            select(ConditionOccurrence.person_id)
+                            .where(ConditionOccurrence.condition_concept_id == rule.concept_id)
+                            .distinct()
+                            .subquery(),
+                            isouter=True
+                        )
+                        .join(
+                            select(Observation.person_id)
+                            .where(Observation.observation_concept_id == rule.concept_id)
+                            .distinct()
+                            .subquery(),
+                            isouter=True
+                        )
+                        .join(
+                            select(DrugExposure.person_id)
+                            .where(DrugExposure.drug_concept_id == rule.concept_id)
+                            .distinct()
+                            .subquery(),
+                            isouter=True
+                        )
                         .subquery()
                     )
                 # Text rules testing for exclusion
@@ -376,6 +404,34 @@ class RQuestQueryBuilder(BaseQueryBuilder):
                             )
                         )
                         .distinct()
+                        .join(
+                            select(ProcedureOccurrence.person_id)
+                            .where(ProcedureOccurrence.procedure_concept_id != rule.concept_id)
+                            .distinct()
+                            .subquery(),
+                            isouter=True
+                        )
+                        .join(
+                            select(ConditionOccurrence.person_id)
+                            .where(ConditionOccurrence.condition_concept_id != rule.concept_id)
+                            .distinct()
+                            .subquery(),
+                            isouter=True
+                        )
+                        .join(
+                            select(Observation.person_id)
+                            .where(Observation.observation_concept_id != rule.concept_id)
+                            .distinct()
+                            .subquery(),
+                            isouter=True
+                        )
+                        .join(
+                            select(DrugExposure.person_id)
+                            .where(DrugExposure.drug_concept_id != rule.concept_id)
+                            .distinct()
+                            .subquery(),
+                            isouter=True
+                        )
                         .subquery()
                     )
                 else:

--- a/app/HutchAgent/hutchagent/query.py
+++ b/app/HutchAgent/hutchagent/query.py
@@ -397,6 +397,7 @@ class RQuestQueryBuilder(BaseQueryBuilder):
         stmnt = select(func.count()).select_from(self.subqueries[0])
         for sq in self.subqueries[1:]:
             stmnt = stmnt.join(sq, isouter=True)
+        self.subqueries = list()
         return stmnt
 
 
@@ -457,4 +458,5 @@ class ROCratesQueryBuilder(BaseQueryBuilder):
         stmnt = select(func.count()).select_from(self.subqueries[0])
         for sq in self.subqueries[1:]:
             stmnt = stmnt.join(sq, isouter=True)
+        self.subqueries = list()
         return stmnt

--- a/app/HutchAgent/hutchagent/query.py
+++ b/app/HutchAgent/hutchagent/query.py
@@ -397,7 +397,7 @@ class RQuestQueryBuilder(BaseQueryBuilder):
         stmnt = select(func.count()).select_from(self.subqueries[0])
         for sq in self.subqueries[1:]:
             stmnt = stmnt.join(sq, isouter=True)
-        self.subqueries = list()
+        self.subqueries.clear()
         return stmnt
 
 
@@ -458,5 +458,5 @@ class ROCratesQueryBuilder(BaseQueryBuilder):
         stmnt = select(func.count()).select_from(self.subqueries[0])
         for sq in self.subqueries[1:]:
             stmnt = stmnt.join(sq, isouter=True)
-        self.subqueries = list()
+        self.subqueries.clear()
         return stmnt

--- a/app/HutchAgent/hutchagent/query.py
+++ b/app/HutchAgent/hutchagent/query.py
@@ -463,84 +463,76 @@ class ROCratesQueryBuilder(BaseQueryBuilder):
                 if rule.value is not None and rule.operator == "=":
                     self.subqueries.append(
                         select(Person.person_id)
+                        .join(
+                            ProcedureOccurrence,
+                            Person.person_id == ProcedureOccurrence.person_id,
+                            isouter=True,
+                        )
+                        .join(
+                            ConditionOccurrence,
+                            Person.person_id == ConditionOccurrence.person_id,
+                            isouter=True,
+                        )
+                        .join(
+                            Observation,
+                            Person.person_id == Observation.person_id,
+                            isouter=True,
+                        )
+                        .join(
+                            DrugExposure,
+                            Person.person_id == DrugExposure.person_id,
+                            isouter=True,
+                        )
                         .where(
                             or_(
                                 Person.ethnicity_concept_id == rule.concept_id,
                                 Person.gender_concept_id == rule.concept_id,
                                 Person.race_concept_id == rule.concept_id,
+                                ProcedureOccurrence.procedure_concept_id == rule.concept_id,
+                                ConditionOccurrence.condition_concept_id == rule.concept_id,
+                                Observation.observation_concept_id == rule.concept_id,
+                                DrugExposure.drug_concept_id == rule.concept_id,
                             )
                         )
                         .distinct()
-                        .join(
-                            select(ProcedureOccurrence.person_id)
-                            .where(ProcedureOccurrence.procedure_concept_id == rule.concept_id)
-                            .distinct()
-                            .subquery(),
-                            isouter=True
-                        )
-                        .join(
-                            select(ConditionOccurrence.person_id)
-                            .where(ConditionOccurrence.condition_concept_id == rule.concept_id)
-                            .distinct()
-                            .subquery(),
-                            isouter=True
-                        )
-                        .join(
-                            select(Observation.person_id)
-                            .where(Observation.observation_concept_id == rule.concept_id)
-                            .distinct()
-                            .subquery(),
-                            isouter=True
-                        )
-                        .join(
-                            select(DrugExposure.person_id)
-                            .where(DrugExposure.drug_concept_id == rule.concept_id)
-                            .distinct()
-                            .subquery(),
-                            isouter=True
-                        )
                         .subquery()
                     )
                 # Text rules testing for exclusion
                 elif rule.value is not None and rule.operator == "!=":
                     self.subqueries.append(
                         select(Person.person_id)
+                        .join(
+                            ProcedureOccurrence,
+                            Person.person_id == ProcedureOccurrence.person_id,
+                            isouter=True,
+                        )
+                        .join(
+                            ConditionOccurrence,
+                            Person.person_id == ConditionOccurrence.person_id,
+                            isouter=True,
+                        )
+                        .join(
+                            Observation,
+                            Person.person_id == Observation.person_id,
+                            isouter=True,
+                        )
+                        .join(
+                            DrugExposure,
+                            Person.person_id == DrugExposure.person_id,
+                            isouter=True,
+                        )
                         .where(
                             or_(
                                 Person.ethnicity_concept_id != rule.concept_id,
                                 Person.gender_concept_id != rule.concept_id,
                                 Person.race_concept_id != rule.concept_id,
+                                ProcedureOccurrence.procedure_concept_id != rule.concept_id,
+                                ConditionOccurrence.condition_concept_id != rule.concept_id,
+                                Observation.observation_concept_id != rule.concept_id,
+                                DrugExposure.drug_concept_id != rule.concept_id,
                             )
                         )
                         .distinct()
-                        .join(
-                            select(ProcedureOccurrence.person_id)
-                            .where(ProcedureOccurrence.procedure_concept_id != rule.concept_id)
-                            .distinct()
-                            .subquery(),
-                            isouter=True
-                        )
-                        .join(
-                            select(ConditionOccurrence.person_id)
-                            .where(ConditionOccurrence.condition_concept_id != rule.concept_id)
-                            .distinct()
-                            .subquery(),
-                            isouter=True
-                        )
-                        .join(
-                            select(Observation.person_id)
-                            .where(Observation.observation_concept_id != rule.concept_id)
-                            .distinct()
-                            .subquery(),
-                            isouter=True
-                        )
-                        .join(
-                            select(DrugExposure.person_id)
-                            .where(DrugExposure.drug_concept_id != rule.concept_id)
-                            .distinct()
-                            .subquery(),
-                            isouter=True
-                        )
                         .subquery()
                     )
                 else:

--- a/app/HutchAgent/hutchagent/ro_crates/group.py
+++ b/app/HutchAgent/hutchagent/ro_crates/group.py
@@ -8,7 +8,7 @@ from hutchagent.ro_crates.thing import Thing
 
 
 class Group(Thing):
-    """Python representation of an group based on [ItemList](https://schema.org/ItemList)."""
+    """Python representation of a group based on [ItemList](https://schema.org/ItemList)."""
 
     def __init__(
         self,
@@ -16,13 +16,13 @@ class Group(Thing):
         type_: str,
         name: str,
         number_of_items: int,
-        item_list_element: List[Rule],
+        rules: List[Rule],
         rule_operator: Operator,
         **kwargs
     ) -> None:
         super().__init__(context, type_, name)
         self.number_of_items = number_of_items
-        self.item_list_element = item_list_element
+        self.rules = rules
         self.rule_operator = rule_operator
 
     def to_dict(self) -> dict:
@@ -33,7 +33,7 @@ class Group(Thing):
         """
         item_list_element = [self.rule_operator.to_dict()]
         item_list_element.extend(
-            [element.to_dict() for element in self.item_list_element]
+            [element.to_dict() for element in self.rules]
         )
         return {
             "@context": self.context,
@@ -41,7 +41,7 @@ class Group(Thing):
             "name": self.name,
             "numberOfItems": self.number_of_items,
             "itemListElement": [self.rule_operator.to_dict()]
-            + [element.to_dict() for element in self.item_list_element],
+            + [element.to_dict() for element in self.rules],
         }
 
     @classmethod
@@ -55,27 +55,27 @@ class Group(Thing):
             Self: `Group` object.
         """
 
-        item_list_element = []
+        rules = []
         operator = None
         for i in dict_.get("itemListElement", []):
             if i.get("name") == "ruleOperator":
                 operator = Operator.from_dict(i)
             else:
-                item_list_element.append(Rule.from_dict(i))
+                rules.append(Rule.from_dict(i))
         return cls(
             context=dict_.get("@context"),
             type_=dict_.get("@type"),
             name=dict_.get("name"),
             number_of_items=dict_.get("numberOfItems"),
-            item_list_element=item_list_element,
+            rules=rules,
             rule_operator=operator,
         )
 
     @property
     def sql_clause(self):
         if self.rule_operator.value == "AND":
-            return and_(*[rule.sql_clause for rule in self.item_list_element])
-        return or_(*[rule.sql_clause for rule in self.item_list_element])
+            return and_(*[rule.sql_clause for rule in self.rules])
+        return or_(*[rule.sql_clause for rule in self.rules])
 
     def __str__(self) -> str:
         """`Group` as a JSON string.

--- a/app/HutchAgent/tests/test_query.py
+++ b/app/HutchAgent/tests/test_query.py
@@ -178,8 +178,10 @@ def test_cohort_sql_clause():
         "groups_oper": "AND",
     }
     cohort = query.RQuestQueryCohort(**and_group)
+    cohort.groups[0].rules[0].set_table(entities.Person)
+    cohort.groups[0].rules[0].set_column(entities.Person.race_concept_id)
     # Assert single rule in single group builds correctly
-    assert str(cohort.sql_clause) == "race_concept_id = :race_concept_id_1"
+    assert str(cohort.sql_clause) == "person.race_concept_id = :race_concept_id_1"
     and_group["groups"][0]["rules"].append(
         {
             "varname": "OMOP",
@@ -189,10 +191,14 @@ def test_cohort_sql_clause():
         }
     )
     cohort = query.RQuestQueryCohort(**and_group)
+    cohort.groups[0].rules[0].set_table(entities.Person)
+    cohort.groups[0].rules[0].set_column(entities.Person.race_concept_id)
+    cohort.groups[0].rules[1].set_table(entities.Person)
+    cohort.groups[0].rules[1].set_column(entities.Person.gender_concept_id)
     # Assert multiple rules in single group build correctly
     assert (
         str(cohort.sql_clause)
-        == "gender_concept_id = :gender_concept_id_1 OR race_concept_id = :race_concept_id_1"
+        == "person.race_concept_id = :race_concept_id_1 OR person.gender_concept_id = :gender_concept_id_1"
     )
     and_group["groups"].append(
         {
@@ -209,9 +215,15 @@ def test_cohort_sql_clause():
     )
     # Assert multiple rules in multiple groups build correctly
     cohort = query.RQuestQueryCohort(**and_group)
+    cohort.groups[0].rules[0].set_table(entities.Person)
+    cohort.groups[0].rules[0].set_column(entities.Person.race_concept_id)
+    cohort.groups[0].rules[1].set_table(entities.Person)
+    cohort.groups[0].rules[1].set_column(entities.Person.gender_concept_id)
+    cohort.groups[1].rules[0].set_table(entities.Person)
+    cohort.groups[1].rules[0].set_column(entities.Person.gender_concept_id)
     assert (
         str(cohort.sql_clause)
-        == "(gender_concept_id = :gender_concept_id_1 OR race_concept_id = :race_concept_id_1) AND gender_concept_id = :gender_concept_id_2"
+        == "(person.race_concept_id = :race_concept_id_1 OR person.gender_concept_id = :gender_concept_id_1) AND person.gender_concept_id = :gender_concept_id_2"
     )
 
 

--- a/app/HutchAgent/tests/test_query.py
+++ b/app/HutchAgent/tests/test_query.py
@@ -136,8 +136,10 @@ def test_group_sql_clause():
         "rules_oper": "OR",
     }
     group = query.RQuestQueryGroup(**and_rule)
+    group.rules[0].set_table(entities.Person)
+    group.rules[0].set_column(entities.Person.race_concept_id)
     # Assert single rule in group builds correctly
-    assert str(group.sql_clause) == "race_concept_id = :race_concept_id_1"
+    assert str(group.sql_clause) == "person.race_concept_id = :race_concept_id_1"
     and_rule["rules"].append(
         {
             "varname": "OMOP",
@@ -147,10 +149,14 @@ def test_group_sql_clause():
         },
     )
     group = query.RQuestQueryGroup(**and_rule)
+    group.rules[0].set_table(entities.Person)
+    group.rules[0].set_column(entities.Person.race_concept_id)
+    group.rules[1].set_table(entities.Person)
+    group.rules[1].set_column(entities.Person.gender_concept_id)
     # Assert multiple rules in group build correctly
     assert (
         str(group.sql_clause)
-        == "gender_concept_id = :gender_concept_id_1 OR race_concept_id = :race_concept_id_1"
+        == "person.race_concept_id = :race_concept_id_1 OR person.gender_concept_id = :gender_concept_id_1"
     )
 
 

--- a/app/HutchAgent/tests/test_query.py
+++ b/app/HutchAgent/tests/test_query.py
@@ -1,5 +1,6 @@
 import pytest
 import hutchagent.query as query
+import hutchagent.entities as entities
 
 
 def test_create_rquest_query():
@@ -48,11 +49,13 @@ def test_text_rule_sql_clause():
     }
     rule_obj = query.RQuestQueryRule(**eq_rule)
     assert rule_obj.concept_id == "8527"
-    assert str(rule_obj.sql_clause) == "race_concept_id = :race_concept_id_1"
+    rule_obj.set_column(entities.Person.race_concept_id)
+    assert str(rule_obj.sql_clause) == "person.race_concept_id = :race_concept_id_1"
     ne_rule = eq_rule.copy()
     ne_rule.update(oper="!=")
     rule_obj = query.RQuestQueryRule(**ne_rule)
-    assert str(rule_obj.sql_clause) == "race_concept_id != :race_concept_id_1"
+    rule_obj.set_column(entities.Person.race_concept_id)
+    assert str(rule_obj.sql_clause) == "person.race_concept_id != :race_concept_id_1"
 
 
 def test_numeric_rule_sql_clause():
@@ -63,21 +66,22 @@ def test_numeric_rule_sql_clause():
         "value": "10..20",
     }
     rule_obj = query.RQuestQueryRule(**eq_rule)
+    rule_obj.set_column(entities.Person.race_concept_id)
     assert rule_obj.concept_id == "8527"
     assert (
         str(rule_obj.sql_clause)
-        == "race_concept_id BETWEEN :race_concept_id_1 AND :race_concept_id_2"
+        == "person.race_concept_id BETWEEN :race_concept_id_1 AND :race_concept_id_2"
     )
     ne_rule = eq_rule.copy()
     ne_rule.update(oper="!=")
     rule_obj = query.RQuestQueryRule(**ne_rule)
+    rule_obj.set_column(entities.Person.race_concept_id)
     assert (
         str(rule_obj.sql_clause)
-        == "race_concept_id NOT BETWEEN :race_concept_id_1 AND :race_concept_id_2"
+        == "person.race_concept_id NOT BETWEEN :race_concept_id_1 AND :race_concept_id_2"
     )
 
 
-# @pytest.mark.skip
 def test_time_rule_sql_clause():
     eq_rule = {
         "varname": "OMOP",
@@ -87,26 +91,34 @@ def test_time_rule_sql_clause():
         "time": "18|:AGE:Y",
     }
     rule_obj = query.RQuestQueryRule(**eq_rule)
+    rule_obj.set_table(entities.Person)
+    rule_obj.set_column(entities.Person.race_concept_id)
     assert rule_obj.concept_id == "8527"
     assert (
         str(rule_obj.sql_clause)
-        == "race_concept_id = :race_concept_id_1 AND birth_datetime > :birth_datetime_1"
+        == "person.race_concept_id = :race_concept_id_1 AND person.birth_datetime > :birth_datetime_1"
     )
     ne_rule = eq_rule.copy()
     ne_rule.update(oper="!=")
     rule_obj = query.RQuestQueryRule(**ne_rule)
+    rule_obj.set_table(entities.Person)
+    rule_obj.set_column(entities.Person.race_concept_id)
     assert (
         str(rule_obj.sql_clause)
-        == "race_concept_id != :race_concept_id_1 AND birth_datetime <= :birth_datetime_1"
+        == "person.race_concept_id != :race_concept_id_1 AND person.birth_datetime <= :birth_datetime_1"
     )
     ne_rule.update(time="|18:AGE:Y")
     rule_obj = query.RQuestQueryRule(**ne_rule)
+    rule_obj.set_table(entities.Person)
+    rule_obj.set_column(entities.Person.race_concept_id)
     assert (
         str(rule_obj.sql_clause)
-        == "race_concept_id != :race_concept_id_1 AND birth_datetime >= :birth_datetime_1"
+        == "person.race_concept_id != :race_concept_id_1 AND person.birth_datetime >= :birth_datetime_1"
     )
     ne_rule.update(time="|18|:AGE:Y")
     rule_obj = query.RQuestQueryRule(**ne_rule)
+    rule_obj.set_table(entities.Person)
+    rule_obj.set_column(entities.Person.race_concept_id)
     with pytest.raises(ValueError):
         print(rule_obj.sql_clause)
 

--- a/app/HutchAgent/tests/test_ro_crates.py
+++ b/app/HutchAgent/tests/test_ro_crates.py
@@ -76,8 +76,8 @@ def test_rule():
 
 def test_group():
     group = Group.from_dict(GROUP_DICT)
-    assert len(group.item_list_element) == GROUP_DICT["numberOfItems"]
-    for element in group.item_list_element:
+    assert len(group.rules) == GROUP_DICT["numberOfItems"]
+    for element in group.rules:
         assert isinstance(element, Rule)
     assert isinstance(group.rule_operator, Operator)
     assert group.to_dict() == GROUP_DICT


### PR DESCRIPTION
## Overview

- Introduce query builder classes for RQuest and RO-Crates queries which brute force query all the tables.
- Use the query builders in callbacks.
- Queries join subqueries to other tables besides `Person`.

## Azure Boards

- [AB#68172](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/68172)
- [AB#68362](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/68362)
- [AB#69514](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/69514)
- [AB#69580](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/69580)
- [AB#68171](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/68171)
- [AB#68173](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/68173)

## Notes

- Update RO-Crates objects to work a bit more like RQuest queries
  - rename `item_list_element` to `rules` (will still use the shema.org name when converting to and from JSON)
- Added `set_table` and `set_column` methods to `RQuestRule` to be used when we are in a position to more dynamically query the OMOP DB.