### PR TITLE
AB#69935: CI to publish distributable artifacts (Agent)

### DIFF
--- a/.github/workflows/publish.agent-wheel.yml
+++ b/.github/workflows/publish.agent-wheel.yml
@@ -37,7 +37,7 @@ jobs:
         run: poetry build
       - uses: ncipollo/release-action@v1.10.0
         with:
-          artifacts: "./hutchagent*.tar.gz,./hutchagent*.whl"
+          artifacts: "${{ env.WORKDIR }}/hutchagent*.tar.gz,${{ env.WORKDIR }}/hutchagent*.whl"
           tag: hutchagent
 
 

--- a/.github/workflows/publish.agent-wheel.yml
+++ b/.github/workflows/publish.agent-wheel.yml
@@ -2,13 +2,14 @@ name: Publish Agent Wheel
 
 on:
   workflow_dispatch: # manual trigger
-    # inputs:
-    #   buildConfig:
-    #     description: Build Configuration
-    #     required: true
-    #     default: release
-  # push:
-  #   branches: [main, support/*]
+    inputs:
+      buildConfig:
+        description: Build Configuration
+        required: true
+        default: release
+  push:
+    # branches: [main, support/*]
+    branches: [feature/agent-wheel-CI]  # remove this line when ready for merge to main
 
 jobs:
   publish-wheel:

--- a/.github/workflows/publish.agent-wheel.yml
+++ b/.github/workflows/publish.agent-wheel.yml
@@ -20,6 +20,7 @@ jobs:
       PYTHON_VERSION: "3.9"
       POETRY_VERSION: "1.1.14"
       WORKDIR: "./app/HutchAgent"
+      ARTIFACT_NAME: "hutchagent-dist"
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
@@ -35,10 +36,15 @@ jobs:
       - name: Build dist
         working-directory: ${{ env.WORKDIR }}
         run: poetry build
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.WORKDIR }}/dist
       - uses: ncipollo/release-action@v1.10.0
         with:
           artifacts: "${{ env.WORKDIR }}/hutchagent*.tar.gz,${{ env.WORKDIR }}/hutchagent*.whl"
           tag: hutchagent
+          omitBody: true
 
 
 

--- a/.github/workflows/publish.agent-wheel.yml
+++ b/.github/workflows/publish.agent-wheel.yml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   publish-wheel:
+    permissions:
+      actions: write
     runs-on: ubuntu-latest
     env:
       PYTHON_VERSION: "3.9"

--- a/.github/workflows/publish.agent-wheel.yml
+++ b/.github/workflows/publish.agent-wheel.yml
@@ -2,11 +2,11 @@ name: Publish Agent Wheel
 
 on:
   workflow_dispatch: # manual trigger
-    inputs:
-      buildConfig:
-        description: Build Configuration
-        required: true
-        default: release
+    # inputs:
+    #   buildConfig:
+    #     description: Build Configuration
+    #     required: true
+    #     default: release
   # push:
   #   branches: [main, support/*]
 

--- a/.github/workflows/publish.agent-wheel.yml
+++ b/.github/workflows/publish.agent-wheel.yml
@@ -33,9 +33,7 @@ jobs:
       - name: Build dist
         working-directory: ${{ env.WORKDIR }}
         run: poetry build
-      - name: Publish dist
-        working-directory: ${{ env.WORKDIR }}
-        uses: ncipollo/release-action@v1.10.0
+      - uses: ncipollo/release-action@v1.10.0
         with:
           artifacts: ["./hutchagent*.tar.gz", "./hutchagent*.whl"]
           tag: hutchagent

--- a/.github/workflows/publish.agent-wheel.yml
+++ b/.github/workflows/publish.agent-wheel.yml
@@ -1,0 +1,27 @@
+name: Publish Agent Wheel
+
+on:
+  workflow_dispatch: # manual trigger
+    inputs:
+      buildConfig:
+        description: Build Configuration
+        required: true
+        default: release
+  # push:
+  #   branches: [main, support/*]
+
+jobs:
+  publish-wheel:
+    runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: "3.9"
+      POETRY_VERSION: "1.1.14"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install poetry
+        working-directory: ./app/HutchAgent
+        run: pip install poetry==${{ env.POETRY_VERSION }}

--- a/.github/workflows/publish.agent-wheel.yml
+++ b/.github/workflows/publish.agent-wheel.yml
@@ -35,7 +35,7 @@ jobs:
         run: poetry build
       - uses: ncipollo/release-action@v1.10.0
         with:
-          artifacts: ["./hutchagent*.tar.gz", "./hutchagent*.whl"]
+          artifacts: "./hutchagent*.tar.gz,./hutchagent*.whl"
           tag: hutchagent
 
 

--- a/.github/workflows/publish.agent-wheel.yml
+++ b/.github/workflows/publish.agent-wheel.yml
@@ -30,9 +30,8 @@ jobs:
       - name: Install agent deps
         working-directory: ${{ env.WORKDIR }}
         run: poetry install --no-dev
-      - name: Publish dist
+      - uses: ncipollo/release-action@v1.10.0
         working-directory: ${{ env.WORKDIR }}
-        uses: ncipollo/release-action@v1.10.0
         with:
           artifacts: ["./hutchagent*.tar.gz", "./hutchagent*.whl"]
           tag: hutchagent

--- a/.github/workflows/publish.agent-wheel.yml
+++ b/.github/workflows/publish.agent-wheel.yml
@@ -8,8 +8,7 @@ on:
         required: true
         default: release
   push:
-    # branches: [main, support/*]
-    branches: [feature/agent-wheel-CI]  # remove this line when ready for merge to main
+    branches: [main]
 
 jobs:
   publish-wheel:
@@ -41,6 +40,3 @@ jobs:
           artifacts: "${{ env.WORKDIR }}/dist/hutchagent*.tar.gz,${{ env.WORKDIR }}/dist/hutchagent*.whl"
           tag: hutchagent
           omitBody: true
-
-
-

--- a/.github/workflows/publish.agent-wheel.yml
+++ b/.github/workflows/publish.agent-wheel.yml
@@ -30,8 +30,9 @@ jobs:
       - name: Install agent deps
         working-directory: ${{ env.WORKDIR }}
         run: poetry install --no-dev
-      - uses: ncipollo/release-action@v1.10.0
+      - name: Publish dist
         working-directory: ${{ env.WORKDIR }}
+        uses: ncipollo/release-action@v1.10.0
         with:
           artifacts: ["./hutchagent*.tar.gz", "./hutchagent*.whl"]
           tag: hutchagent

--- a/.github/workflows/publish.agent-wheel.yml
+++ b/.github/workflows/publish.agent-wheel.yml
@@ -42,7 +42,7 @@ jobs:
           path: ${{ env.WORKDIR }}/dist
       - uses: ncipollo/release-action@v1.10.0
         with:
-          artifacts: "${{ env.WORKDIR }}/hutchagent*.tar.gz,${{ env.WORKDIR }}/hutchagent*.whl"
+          artifacts: "${{ env.WORKDIR }}/dist/hutchagent*.tar.gz,${{ env.WORKDIR }}/dist/hutchagent*.whl"
           tag: hutchagent
           omitBody: true
 

--- a/.github/workflows/publish.agent-wheel.yml
+++ b/.github/workflows/publish.agent-wheel.yml
@@ -36,10 +36,6 @@ jobs:
       - name: Build dist
         working-directory: ${{ env.WORKDIR }}
         run: poetry build
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: ${{ env.WORKDIR }}/dist
       - uses: ncipollo/release-action@v1.10.0
         with:
           artifacts: "${{ env.WORKDIR }}/dist/hutchagent*.tar.gz,${{ env.WORKDIR }}/dist/hutchagent*.whl"

--- a/.github/workflows/publish.agent-wheel.yml
+++ b/.github/workflows/publish.agent-wheel.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install agent deps
         working-directory: ${{ env.WORKDIR }}
         run: poetry install --no-dev
+      - name: Build dist
+        working-directory: ${{ env.WORKDIR }}
+        run: poetry build
       - name: Publish dist
         working-directory: ${{ env.WORKDIR }}
         uses: ncipollo/release-action@v1.10.0

--- a/.github/workflows/publish.agent-wheel.yml
+++ b/.github/workflows/publish.agent-wheel.yml
@@ -17,6 +17,7 @@ jobs:
     env:
       PYTHON_VERSION: "3.9"
       POETRY_VERSION: "1.1.14"
+      WORKDIR: "./app/HutchAgent"
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
@@ -24,5 +25,8 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install poetry
-        working-directory: ./app/HutchAgent
+        working-directory: ${{ env.WORKDIR }}
         run: pip install poetry==${{ env.POETRY_VERSION }}
+      - name: Install agent deps
+        working-directory: ${{ env.WORKDIR }}
+        run: poetry install --no-dev

--- a/.github/workflows/publish.agent-wheel.yml
+++ b/.github/workflows/publish.agent-wheel.yml
@@ -30,3 +30,12 @@ jobs:
       - name: Install agent deps
         working-directory: ${{ env.WORKDIR }}
         run: poetry install --no-dev
+      - name: Publish dist
+        working-directory: ${{ env.WORKDIR }}
+        uses: ncipollo/release-action@v1.10.0
+        with:
+          artifacts: ["./hutchagent*.tar.gz", "./hutchagent*.whl"]
+          tag: hutchagent
+
+
+

--- a/.github/workflows/publish.agent-wheel.yml
+++ b/.github/workflows/publish.agent-wheel.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   publish-wheel:
     permissions:
-      actions: write
+      contents: write
     runs-on: ubuntu-latest
     env:
       PYTHON_VERSION: "3.9"


### PR DESCRIPTION
## Overview

Workflow to publish hutch agent distribution to release.
- publishes to tag `hutchagent` on push to `main`.
- produces the pip wheel (`.whl`) and the `.tar.gz` archive

## Azure Boards

- AB#74903
- AB#74904
- AB#75054
