### PR TITLE
AB#75070: CI to build Agent docker image artefact

### DIFF
--- a/.github/workflows/publish.agent-docker.yml
+++ b/.github/workflows/publish.agent-docker.yml
@@ -10,3 +10,17 @@ on:
   push:
     # branches: [main]
     branches: [feature/agent-docker-CI]  # remove before merge to main
+
+jobs:
+  publish-sargassure:
+    runs-on: ubuntu-latest
+    env:
+      WORKDIR: ./app/HutchAgent
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v3.1.1
+        with:
+          push: false
+          tags: hutchagent:latest
+          context: ${{ env.WORKDIR }}

--- a/.github/workflows/publish.agent-docker.yml
+++ b/.github/workflows/publish.agent-docker.yml
@@ -29,4 +29,5 @@ jobs:
         uses: ishworkh/docker-image-artifact-upload@v1
         with:
           image: ${{ env.IMAGE }}
+        outputs:
           artifact_name: ${{ env.IMAGE }}

--- a/.github/workflows/publish.agent-docker.yml
+++ b/.github/workflows/publish.agent-docker.yml
@@ -17,6 +17,8 @@ jobs:
     env:
       IMAGE: hutchagent:latest
       WORKDIR: ./app/HutchAgent
+    outputs:
+      artifact_name: ${{ env.IMAGE }}
     steps:
       - uses: actions/checkout@v2
       - name: Build and push Docker images
@@ -29,5 +31,3 @@ jobs:
         uses: ishworkh/docker-image-artifact-upload@v1
         with:
           image: ${{ env.IMAGE }}
-        outputs:
-          artifact_name: ${{ env.IMAGE }}

--- a/.github/workflows/publish.agent-docker.yml
+++ b/.github/workflows/publish.agent-docker.yml
@@ -29,3 +29,4 @@ jobs:
         uses: ishworkh/docker-image-artifact-upload@v1
         with:
           image: ${{ env.IMAGE }}
+          artifact_name: ${{ env.IMAGE }}

--- a/.github/workflows/publish.agent-docker.yml
+++ b/.github/workflows/publish.agent-docker.yml
@@ -8,8 +8,7 @@ on:
         required: true
         default: release
   push:
-    # branches: [main]
-    branches: [feature/agent-docker-CI]  # remove before merge to main
+    branches: [main]
 
 jobs:
   publish-agent-docker:
@@ -17,8 +16,6 @@ jobs:
     env:
       IMAGE: hutchagent:latest
       WORKDIR: ./app/HutchAgent
-    outputs:
-      artifact_name: ${{ env.IMAGE }}
     steps:
       - uses: actions/checkout@v2
       - name: Build and push Docker images

--- a/.github/workflows/publish.agent-docker.yml
+++ b/.github/workflows/publish.agent-docker.yml
@@ -12,7 +12,7 @@ on:
     branches: [feature/agent-docker-CI]  # remove before merge to main
 
 jobs:
-  publish-sargassure:
+  publish-agent-docker:
     runs-on: ubuntu-latest
     env:
       WORKDIR: ./app/HutchAgent

--- a/.github/workflows/publish.agent-docker.yml
+++ b/.github/workflows/publish.agent-docker.yml
@@ -1,0 +1,12 @@
+name: Publish Agent Docker
+
+on:
+  workflow_dispatch: # manual trigger
+    inputs:
+      buildConfig:
+        description: Build Configuration
+        required: true
+        default: release
+  push:
+    # branches: [main]
+    branches: [feature/agent-docker-CI]  # remove before merge to main

--- a/.github/workflows/publish.agent-docker.yml
+++ b/.github/workflows/publish.agent-docker.yml
@@ -15,6 +15,7 @@ jobs:
   publish-agent-docker:
     runs-on: ubuntu-latest
     env:
+      IMAGE: hutchagent:latest
       WORKDIR: ./app/HutchAgent
     steps:
       - uses: actions/checkout@v2
@@ -22,5 +23,9 @@ jobs:
         uses: docker/build-push-action@v3.1.1
         with:
           push: false
-          tags: hutchagent:latest
+          tags: ${{ env.IMAGE }}
           context: ${{ env.WORKDIR }}
+      - name: Docker Image Artifact Upload
+        uses: ishworkh/docker-image-artifact-upload@v1
+        with:
+          image: ${{ env.IMAGE }}

--- a/app/HutchAgent/Dockerfile
+++ b/app/HutchAgent/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9.12-buster
 WORKDIR /HutchAgent
 COPY . .
 RUN pip install --upgrade pip
-RUN pip install poetry==1.1.3
+RUN pip install poetry==1.1.14
 RUN poetry install --no-dev
 EXPOSE 3030
 CMD ["poetry", "run", "hutchagent"]


### PR DESCRIPTION
## Overview

Workflow to build hutchagent docker image as an artifact.
- appears as `action_image_artifact_hutchagent_latest` since the name isn't configurable in the workflow 👎 

## Azure Boards

- [AB#75072](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/75072)
- [AB#75073](https://dev.azure.com/UniversityOfNottingham/bd2de5ba-2a41-4bdc-a444-61e6b706132a/_workitems/edit/75073)
